### PR TITLE
fix(bank): zpracovat karetní avíza Raiffeisenbank

### DIFF
--- a/api/src/Service/Bank/EmailNotice/Parser/RaiffeisenbankEmailNoticeParser.php
+++ b/api/src/Service/Bank/EmailNotice/Parser/RaiffeisenbankEmailNoticeParser.php
@@ -31,7 +31,7 @@ final class RaiffeisenbankEmailNoticeParser extends AbstractBankEmailNoticeParse
             enabled: true,
             senderWhitelist: 'info@rb.cz',
             subjectPattern: 'Pohyb\\s+na\\s+účtě|Pohyb\\s+na\\s+ucte',
-            bodyPattern: 'Variabilní\\s+symbol',
+            bodyPattern: 'Variabilní\\s+symbol|Debetní\\s+karta',
             fieldPatterns: [],
             normalizerConfig: [],
             system: true,
@@ -47,10 +47,16 @@ final class RaiffeisenbankEmailNoticeParser extends AbstractBankEmailNoticeParse
         if (!str_contains($subject, 'pohyb na účtě') && !str_contains($subject, 'pohyb na ucte')) {
             return false;
         }
-        $text = mb_strtolower($this->normalizeText($message->text));
-        return str_contains($text, 'variabilní symbol')
-            && str_contains($text, 'částka v měně účtu')
-            && str_contains($text, 'na účet');
+        $text = $this->normalizeText($message->text);
+        $folded = mb_strtolower($this->foldDiacritics($text));
+        if (!str_contains($folded, 'castka v mene uctu')) {
+            return false;
+        }
+
+        $isTransfer = str_contains($folded, 'variabilni symbol')
+            && str_contains($folded, 'na ucet');
+
+        return $isTransfer || $this->isCardTransaction($text);
     }
 
     public function parse(BankEmailNoticeMessage $message, BankEmailNoticeProvider $provider): ParsedBankEmailNotice
@@ -63,6 +69,32 @@ final class RaiffeisenbankEmailNoticeParser extends AbstractBankEmailNoticeParse
             throw new \RuntimeException('Raiffeisenbank parser nenašel částku a měnu.');
         }
         $amount = $this->parseAmount((string) $amountCurrency['amount']);
+        $constantSymbol = $this->optional($text, '/Konstantní\s+symbol\s*(?<value>[0-9]+)/iu');
+        $balance = $this->optional($text, '/Disponibilní\s+zůstatek(?:\s+po\s+pohybu)?\s*(?<value>[+\-]?[0-9][0-9 .]*,[0-9]{2})/iu');
+
+        if ($this->isCardTransaction($text)) {
+            $ownAccount = $this->required(
+                $text,
+                '/(?:^|\R)\s*Účet\s*(?<value>[0-9\-]+\/[0-9]{4})/iu',
+                'vlastní účet',
+            );
+            $details = $this->optional(
+                $text,
+                '/Detaily\s*(?<value>.*?)Disponibilní\s+zůstatek/isu',
+            );
+
+            return new ParsedBankEmailNotice(
+                variableSymbol: '',
+                amount: $amount,
+                currency: strtoupper((string) $amountCurrency['currency']),
+                postedAt: $this->parseDate($postedAt),
+                recipientAccount: $ownAccount,
+                counterpartyName: $details,
+                constantSymbol: $constantSymbol,
+                balance: $balance !== null ? $this->parseAmount($balance) : null,
+            );
+        }
+
         $to = $this->match(
             $text,
             '/Na\s+účet\s*(?<account>[0-9\-]+\/[0-9]{4})(?<name>.*?)(?=Částka\s+v\s+měně\s+účtu|Variabilní\s+symbol)/isu',
@@ -75,9 +107,7 @@ final class RaiffeisenbankEmailNoticeParser extends AbstractBankEmailNoticeParse
             '/Z\s+účtu\s*(?<account>[0-9\-]+\/[0-9]{4})(?<name>.*?)(?=Částka\s+v\s+měně\s+účtu|Variabilní\s+symbol)/isu',
         );
         $variableSymbol = $this->required($text, '/Variabilní\s+symbol\s*(?<value>[0-9]+)/iu', 'variabilní symbol');
-        $constantSymbol = $this->optional($text, '/Konstantní\s+symbol\s*(?<value>[0-9]+)/iu');
         $note = $this->optional($text, '/Zpráva\s+pro\s+příjemce\s*(?<value>.*?)Disponibilní\s+zůstatek/isu');
-        $balance = $this->optional($text, '/Disponibilní\s+zůstatek(?:\s+po\s+pohybu)?\s*(?<value>[+\-]?[0-9][0-9 .]*,[0-9]{2})/iu');
 
         $isOutgoing = $this->isOutgoingTransfer($text, $amount);
         if ($isOutgoing && $from === null) {
@@ -100,6 +130,14 @@ final class RaiffeisenbankEmailNoticeParser extends AbstractBankEmailNoticeParse
             message: $note,
             balance: $balance !== null ? $this->parseAmount($balance) : null,
         );
+    }
+
+    private function isCardTransaction(string $text): bool
+    {
+        $folded = mb_strtolower($this->foldDiacritics($text));
+        return str_contains($folded, 'odchozi karetni transakce')
+            && str_contains($folded, 'debetni karta')
+            && str_contains($folded, 'platba kartou');
     }
 
     private function isOutgoingTransfer(string $text, float $amount): bool

--- a/api/tests/Unit/Bank/RaiffeisenbankEmailNoticeParserTest.php
+++ b/api/tests/Unit/Bank/RaiffeisenbankEmailNoticeParserTest.php
@@ -117,4 +117,63 @@ TEXT;
         self::assertSame('Faktura 2608001', $parsed->message);
         self::assertSame(98765.43, $parsed->balance);
     }
+
+    public function testParsesOutgoingCardTransactionWithoutVariableSymbolOrCounterpartyAccount(): void
+    {
+        $text = <<<TEXT
+Vážená klientko, vážený kliente,
+na účtě byla provedena následující odchozí karetní transakce:
+Datum a čas
+19. 08. 2026 04:41
+Účet
+1000000005/5500Firma Test s.r.o.
+Debetní karta
+123456XXXXXX7890
+Částka v měně účtu
+-1.234,56 CZK
+Původní částka a měna
+-49,99 EUR
+Kurz
+24,70
+Kategorie pohybu
+Platba kartou
+Typ pohybu
+Platba kartou
+Konstantní symbol
+1178
+Detaily
+DEMO SOFTWARE; PRAHA; CZE
+Disponibilní zůstatek po pohybu
++98.765,43 CZK
+TEXT;
+
+        $message = new BankEmailNoticeMessage(
+            uid: 3,
+            messageId: '<sanitized-card@rb.cz>',
+            date: new \DateTimeImmutable('2026-08-19 04:41:00'),
+            sender: 'Raiffeisenbank <info@rb.cz>',
+            subject: 'Pohyb na účtě',
+            text: $text,
+            raw: $text,
+        );
+
+        $parser = new RaiffeisenbankEmailNoticeParser();
+        $provider = $parser->defaultProvider();
+        self::assertInstanceOf(BankEmailNoticeProvider::class, $provider);
+        self::assertTrue($parser->supports($message, $provider));
+
+        $parsed = $parser->parse($message, $provider);
+
+        self::assertSame('', $parsed->variableSymbol);
+        self::assertSame(-1234.56, $parsed->amount);
+        self::assertSame('CZK', $parsed->currency);
+        self::assertSame('2026-08-19', $parsed->postedAt);
+        self::assertSame('1000000005/5500', $parsed->recipientAccount);
+        self::assertNull($parsed->counterpartyAccount);
+        self::assertNull($parsed->counterpartyBank);
+        self::assertSame('DEMO SOFTWARE; PRAHA; CZE', $parsed->counterpartyName);
+        self::assertSame('1178', $parsed->constantSymbol);
+        self::assertNull($parsed->message);
+        self::assertSame(98765.43, $parsed->balance);
+    }
 }

--- a/manual/29_Bankovni_ucty.md
+++ b/manual/29_Bankovni_ucty.md
@@ -193,7 +193,9 @@ Systémový provider Raiffeisenbank rozlišuje směr převodu podle úvodního t
 o příchozí nebo odchozí platbě; u starší či odlišné šablony použije jako záložní
 údaj znaménko částky. U odchozí úhrady je vlastním účtem pole **Z účtu** a
 protiúčtem pole **Na účet**; u příchozí úhrady je to opačně. Díky tomu se odchozí
-avízo mapuje na účet, ze kterého byla platba skutečně odepsána.
+avízo mapuje na účet, ze kterého byla platba skutečně odepsána. U karetní
+transakce se vlastní účet načte z pole **Účet** a obchodník z pole **Detaily**;
+chybějící variabilní symbol ani bankovní protiúčet importu nebrání.
 
 U Air Bank se avíza zapínají v internetovém bankovnictví pod **Účty a karty →
 Možnosti → Info o dění na účtu** (odesílatel `info@airbank.cz`, předměty


### PR DESCRIPTION
# Karetní avíza Raiffeisenbank v bankovním e-mailovém importu

## Shrnutí

Tento PR rozšiřuje systémový parser Raiffeisenbank o odchozí karetní transakce. Karetní avízo nemá variabilní symbol ani bankovní účet protistrany, a proto dosud neprošlo ani výběrem parser provideru a končilo chybou `parse_failed`.

Stávající zpracování příchozích a odchozích bankovních převodů zůstává zachované.

## Problém

Výchozí provider Raiffeisenbank vyžadoval v těle e-mailu text `Variabilní symbol`. Šablona karetního avíza ale obsahuje pole jako `Debetní karta`, `Platba kartou`, `Účet` a `Detaily`, bez VS a bez protiúčtu. Provider proto e-mail odmítl dříve, než se jej parser pokusil vytěžit.

## Řešení

- provider rozpozná vedle převodu také šablonu s debetní kartou,
- detekce klíčových textů je tolerantní k diakritice,
- vlastní bankovní účet se u karetní platby načte z pole `Účet`,
- obchodník se načte z pole `Detaily`,
- zachová se datum, částka, měna, konstantní symbol a disponibilní zůstatek,
- chybějící VS, protiúčet a kód banky se korektně uloží jako prázdné hodnoty,
- transakce pokračuje do existujícího párování přijatých faktur podle částky, data a názvu obchodníka.

## Zpětná kompatibilita

- Příchozí převody se nadále mapují na vlastní účet z pole `Na účet`.
- Odchozí převody se nadále mapují na vlastní účet z pole `Z účtu`.
- Směr převodu se primárně určí z textu avíza, se znaménkem částky jako fallbackem.
- Změna nevyžaduje databázovou migraci ani změnu veřejného API.

## Dokumentace

Manuál bankovních účtů nově popisuje, odkud se u karetního avíza Raiffeisenbank berou vlastní účet a obchodník a že chybějící VS ani protiúčet import neblokují.

## Ověření

- [x] Regresní test odchozí karetní transakce bez VS a protiúčtu
- [x] Ověřeno selhání regresního testu bez opravy: provider avízo odmítl
- [x] Regresní testy stávajícího příchozího a odchozího převodu
- [x] Všechny bankovní unit testy: 73 testů, 364 asercí
- [x] PHP syntax parseru a testu
- [x] Pouze syntetická testovací data
- [x] Regenerace HTML manuálu: 81 kapitol, bez chyby

Cílené testy:

```bash
cd api
php vendor/bin/phpunit --filter RaiffeisenbankEmailNoticeParserTest
php vendor/bin/phpunit tests/Unit/Bank
```

Regenerace manuálu:

```bash
php tools/generateManualHtml.php
```

## Původ backportu

Změna vychází z commitu `ca1cf940` ve větvi `fix/raiffeisenbank-card-email-notice` repozitáře `myinvoice`.
