### PR TITLE
feat(rbac): deleguj provozní nastavení klientům

### DIFF
--- a/api/src/Action/Settings/BrandingProfilesAction.php
+++ b/api/src/Action/Settings/BrandingProfilesAction.php
@@ -8,7 +8,11 @@ use MyInvoice\Http\Json;
 use MyInvoice\Middleware\AuthMiddleware;
 use MyInvoice\Middleware\SupplierScopeMiddleware;
 use MyInvoice\Repository\BrandingProfileRepository;
+use MyInvoice\Security\OperationalSettingsAccess;
+use MyInvoice\Security\RequestAuthorization;
+use MyInvoice\Service\ActivityLogger;
 use MyInvoice\Service\Branding\BrandingProfileValidation;
+use MyInvoice\Service\IpMatcher;
 use MyInvoice\Service\Mail\SupplierLogoConverter;
 use MyInvoice\Service\Pdf\InvoicePdfRenderer;
 use Psr\Http\Message\ResponseInterface as Response;
@@ -23,10 +27,17 @@ final class BrandingProfilesAction
         private readonly BrandingProfileRepository $profiles,
         private readonly SupplierLogoConverter $logoConverter,
         private readonly InvoicePdfRenderer $invoicePdf,
+        private readonly ActivityLogger $logger,
+        private readonly IpMatcher $ipMatcher,
     ) {}
 
     public function list(Request $request, Response $response): Response
     {
+        // Původní staff/demo GET zůstává kompatibilní. Klientská role však smí
+        // profilová data číst až se stejným WRITE právem, které vyžadují mutace.
+        if (RequestAuthorization::isClientType($request) && !$this->canManage($request)) {
+            return Json::error($response, 'forbidden', 'Nemáš oprávnění spravovat branding.', 403);
+        }
         $supplierId = $this->supplierId($request);
         if ($supplierId <= 0) return Json::error($response, 'no_supplier', 'Žádný supplier scope.', 400);
         return Json::ok($response, $this->profiles->listForSupplier($supplierId));
@@ -46,12 +57,13 @@ final class BrandingProfilesAction
 
     public function create(Request $request, Response $response): Response
     {
-        if (!$this->isAdmin($request)) return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        if (!$this->canManage($request)) return Json::error($response, 'forbidden', 'Nemáš oprávnění měnit branding.', 403);
         $supplierId = $this->supplierId($request);
         if ($supplierId <= 0) return Json::error($response, 'no_supplier', 'Žádný supplier scope.', 400);
         if (($gate = $this->requireEnabled($response, $supplierId)) !== null) return $gate;
         $body = (array) ($request->getParsedBody() ?? []);
         $errors = BrandingProfileValidation::validate($body);
+        $errors = array_merge($errors, $this->emailProfileErrors($supplierId, $body));
         if ($errors !== []) return Json::error($response, 'validation_failed', 'Validace selhala', 400, ['fields' => $errors]);
         try {
             $id = $this->profiles->create($supplierId, $body);
@@ -61,12 +73,15 @@ final class BrandingProfilesAction
             }
             throw $e;
         }
-        return Json::ok($response, $this->profiles->findForSupplier($id, $supplierId), 201);
+        $profile = $this->profiles->findForSupplier($id, $supplierId);
+        $this->invoicePdf->invalidateDraftsBySupplier($supplierId);
+        $this->log($request, 'branding_profile.created', $id, ['name' => $profile['name'] ?? null]);
+        return Json::ok($response, $profile, 201);
     }
 
     public function update(Request $request, Response $response, array $args): Response
     {
-        if (!$this->isAdmin($request)) return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        if (!$this->canManage($request)) return Json::error($response, 'forbidden', 'Nemáš oprávnění měnit branding.', 403);
         $supplierId = $this->supplierId($request);
         if (($gate = $this->requireEnabled($response, $supplierId)) !== null) return $gate;
         $id = (int) ($args['id'] ?? 0);
@@ -75,6 +90,7 @@ final class BrandingProfilesAction
         }
         $body = (array) ($request->getParsedBody() ?? []);
         $errors = BrandingProfileValidation::validate($body, true);
+        $errors = array_merge($errors, $this->emailProfileErrors($supplierId, $body));
         if ($errors !== []) return Json::error($response, 'validation_failed', 'Validace selhala', 400, ['fields' => $errors]);
         try {
             $this->profiles->update($id, $supplierId, $body);
@@ -84,23 +100,29 @@ final class BrandingProfilesAction
             }
             throw $e;
         }
-        return Json::ok($response, $this->profiles->findForSupplier($id, $supplierId));
+        $profile = $this->profiles->findForSupplier($id, $supplierId);
+        $this->invoicePdf->invalidateDraftsBySupplier($supplierId);
+        $this->log($request, 'branding_profile.updated', $id, ['fields' => array_keys($body)]);
+        return Json::ok($response, $profile);
     }
 
     public function delete(Request $request, Response $response, array $args): Response
     {
-        if (!$this->isAdmin($request)) return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        if (!$this->canManage($request)) return Json::error($response, 'forbidden', 'Nemáš oprávnění měnit branding.', 403);
         $supplierId = $this->supplierId($request);
         if (($gate = $this->requireEnabled($response, $supplierId)) !== null) return $gate;
         $id = (int) ($args['id'] ?? 0);
+        $existing = $this->profiles->findForSupplier($id, $supplierId);
         $deleted = $this->profiles->delete($id, $supplierId);
         if (!$deleted) return Json::error($response, 'not_found', 'Brandingový profil nenalezen.', 404);
+        $this->invoicePdf->invalidateDraftsBySupplier($supplierId);
+        $this->log($request, 'branding_profile.deleted', $id, ['name' => $existing['name'] ?? null]);
         return Json::ok($response, ['deleted' => true]);
     }
 
     public function setDefault(Request $request, Response $response, array $args): Response
     {
-        if (!$this->isAdmin($request)) return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        if (!$this->canManage($request)) return Json::error($response, 'forbidden', 'Nemáš oprávnění měnit branding.', 403);
         $supplierId = $this->supplierId($request);
         if (($gate = $this->requireEnabled($response, $supplierId)) !== null) return $gate;
         $id = (int) ($args['id'] ?? 0);
@@ -109,12 +131,13 @@ final class BrandingProfilesAction
         }
         $profile = $this->profiles->findForSupplier($id, $supplierId);
         $this->invoicePdf->invalidateDraftsBySupplier($supplierId);
+        $this->log($request, 'branding_profile.default_changed', $id, ['name' => $profile['name'] ?? null]);
         return Json::ok($response, $profile);
     }
 
     public function uploadLogo(Request $request, Response $response, array $args): Response
     {
-        if (!$this->isAdmin($request)) return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        if (!$this->canManage($request)) return Json::error($response, 'forbidden', 'Nemáš oprávnění měnit branding.', 403);
         $supplierId = $this->supplierId($request);
         if (($gate = $this->requireEnabled($response, $supplierId)) !== null) return $gate;
         $id = (int) ($args['id'] ?? 0);
@@ -144,12 +167,18 @@ final class BrandingProfilesAction
         } finally {
             @unlink($tmpPath);
         }
-        return Json::ok($response, $this->profiles->findForSupplier($id, $supplierId));
+        $profile = $this->profiles->findForSupplier($id, $supplierId);
+        $this->invoicePdf->invalidateDraftsBySupplier($supplierId);
+        $this->log($request, 'branding_profile.logo_uploaded', $id, [
+            'width' => $result['width'] ?? null,
+            'height' => $result['height'] ?? null,
+        ]);
+        return Json::ok($response, $profile);
     }
 
     public function deleteLogo(Request $request, Response $response, array $args): Response
     {
-        if (!$this->isAdmin($request)) return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        if (!$this->canManage($request)) return Json::error($response, 'forbidden', 'Nemáš oprávnění měnit branding.', 403);
         $supplierId = $this->supplierId($request);
         if (($gate = $this->requireEnabled($response, $supplierId)) !== null) return $gate;
         $id = (int) ($args['id'] ?? 0);
@@ -157,7 +186,10 @@ final class BrandingProfilesAction
             return Json::error($response, 'not_found', 'Brandingový profil nenalezen.', 404);
         }
         // Soubor záměrně nemažeme: vystavené faktury jej mohou mít ve snapshotu.
-        return Json::ok($response, $this->profiles->findForSupplier($id, $supplierId));
+        $profile = $this->profiles->findForSupplier($id, $supplierId);
+        $this->invoicePdf->invalidateDraftsBySupplier($supplierId);
+        $this->log($request, 'branding_profile.logo_deleted', $id, []);
+        return Json::ok($response, $profile);
     }
 
     /**
@@ -199,9 +231,39 @@ final class BrandingProfilesAction
         return (int) $request->getAttribute(SupplierScopeMiddleware::ATTR_CURRENT_ID, 0);
     }
 
-    private function isAdmin(Request $request): bool
+    /** @param array<string,mixed> $body @return array<string,list<string>> */
+    private function emailProfileErrors(int $supplierId, array $body): array
+    {
+        if (!array_key_exists('email_profile_id', $body)
+            || $body['email_profile_id'] === null
+            || $body['email_profile_id'] === ''
+        ) {
+            return [];
+        }
+        $profileId = (int) $body['email_profile_id'];
+        if ($profileId > 0 && $this->profiles->hasActiveEmailProfile($supplierId, $profileId)) return [];
+
+        return ['email_profile_id' => ['Vybraný e-mailový profil není aktivní v aktuální firmě.']];
+    }
+
+    private function canManage(Request $request): bool
+    {
+        return OperationalSettingsAccess::branding($request);
+    }
+
+    /** @param array<string,mixed> $payload */
+    private function log(Request $request, string $action, int $profileId, array $payload): void
     {
         $user = (array) $request->getAttribute(AuthMiddleware::ATTR_USER, []);
-        return ($user['role'] ?? '') === 'admin';
+        $this->logger->log(
+            $action,
+            isset($user['id']) ? (int) $user['id'] : null,
+            'branding_profile',
+            $profileId,
+            $payload,
+            $this->ipMatcher->clientIpFromRequest($request->getServerParams()),
+            $request->getHeaderLine('User-Agent'),
+            $this->supplierId($request),
+        );
     }
 }

--- a/api/src/Action/Settings/ClientBrandingSettingsAction.php
+++ b/api/src/Action/Settings/ClientBrandingSettingsAction.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Action\Settings;
+
+use MyInvoice\Http\Json;
+use MyInvoice\Infrastructure\Database\Connection;
+use MyInvoice\Middleware\AuthMiddleware;
+use MyInvoice\Middleware\SupplierScopeMiddleware;
+use MyInvoice\Security\OperationalSettingsAccess;
+use MyInvoice\Service\ActivityLogger;
+use MyInvoice\Service\IpMatcher;
+use MyInvoice\Service\Mail\SafeLogoPath;
+use MyInvoice\Service\Pdf\InvoicePdfRenderer;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * Úzký supplier-scoped výřez brandingu pro klientské role s
+ * `settings.company = WRITE`. Záměrně nesdílí mass-assignment se SettingsAction.
+ */
+final class ClientBrandingSettingsAction
+{
+    /** @var list<string> */
+    private const FIELDS = [
+        'email_branding_enabled',
+        'email_accent_color',
+        'pdf_logo_show_name',
+        'branding_profiles_enabled',
+    ];
+
+    public function __construct(
+        private readonly Connection $db,
+        private readonly InvoicePdfRenderer $pdf,
+        private readonly ActivityLogger $logger,
+        private readonly IpMatcher $ipMatcher,
+    ) {}
+
+    public function get(Request $request, Response $response): Response
+    {
+        if (!OperationalSettingsAccess::branding($request)) {
+            return Json::error($response, 'forbidden', 'Nemáš oprávnění měnit provozní nastavení firmy.', 403);
+        }
+        return $this->respond($response, $this->supplierId($request));
+    }
+
+    public function update(Request $request, Response $response): Response
+    {
+        if (!OperationalSettingsAccess::branding($request)) {
+            return Json::error($response, 'forbidden', 'Nemáš oprávnění měnit provozní nastavení firmy.', 403);
+        }
+
+        $supplierId = $this->supplierId($request);
+        if ($supplierId <= 0) {
+            return Json::error($response, 'no_supplier', 'Žádný supplier scope.', 400);
+        }
+
+        $body = (array) ($request->getParsedBody() ?? []);
+        $unknown = array_values(array_diff(array_keys($body), self::FIELDS));
+        if ($unknown !== []) {
+            return Json::error(
+                $response,
+                'field_not_delegable',
+                'Toto nastavení nelze klientské roli delegovat.',
+                403,
+                ['fields' => $unknown],
+            );
+        }
+        if ($body === []) {
+            return $this->respond($response, $supplierId);
+        }
+
+        if (array_key_exists('email_accent_color', $body)) {
+            $color = strtoupper(trim((string) $body['email_accent_color']));
+            if (preg_match('/^#[0-9A-F]{6}$/', $color) !== 1) {
+                return Json::error($response, 'validation_failed', 'Barva musí mít formát #RRGGBB.', 400);
+            }
+            $body['email_accent_color'] = $color;
+        }
+        foreach (array_diff(self::FIELDS, ['email_accent_color']) as $field) {
+            if (!array_key_exists($field, $body)) continue;
+            if (!is_bool($body[$field]) && !in_array($body[$field], [0, 1], true)) {
+                return Json::error(
+                    $response,
+                    'validation_failed',
+                    'Přepínače musí mít logickou hodnotu.',
+                    400,
+                    ['fields' => [$field]],
+                );
+            }
+        }
+
+        $sets = [];
+        $params = [];
+        foreach (self::FIELDS as $field) {
+            if (!array_key_exists($field, $body)) continue;
+            $sets[] = $field . ' = ?';
+            $params[] = $field === 'email_accent_color' ? $body[$field] : ((bool) $body[$field] ? 1 : 0);
+        }
+        $params[] = $supplierId;
+        $stmt = $this->db->pdo()->prepare('UPDATE supplier SET ' . implode(', ', $sets) . ' WHERE id = ?');
+        $stmt->execute($params);
+        if ($stmt->rowCount() === 0 && !$this->supplierExists($supplierId)) {
+            return Json::error($response, 'not_found', 'Supplier nenalezen.', 404);
+        }
+
+        $this->pdf->invalidateDraftsBySupplier($supplierId);
+        $this->log($request, $supplierId, array_keys($body));
+        return $this->respond($response, $supplierId);
+    }
+
+    private function respond(Response $response, int $supplierId): Response
+    {
+        if ($supplierId <= 0) {
+            return Json::error($response, 'no_supplier', 'Žádný supplier scope.', 400);
+        }
+        $stmt = $this->db->pdo()->prepare(
+            'SELECT id, company_name, display_name, email, phone, web, tagline,
+                    email_branding_enabled, email_accent_color, pdf_logo_show_name,
+                    branding_profiles_enabled, default_branding_profile_id, logo_path
+               FROM supplier WHERE id = ?'
+        );
+        $stmt->execute([$supplierId]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return Json::error($response, 'not_found', 'Supplier nenalezen.', 404);
+        }
+
+        $row['id'] = (int) $row['id'];
+        $row['email_branding_enabled'] = (bool) $row['email_branding_enabled'];
+        $row['pdf_logo_show_name'] = (bool) $row['pdf_logo_show_name'];
+        $row['branding_profiles_enabled'] = (bool) $row['branding_profiles_enabled'];
+        $row['default_branding_profile_id'] = $row['default_branding_profile_id'] !== null
+            ? (int) $row['default_branding_profile_id']
+            : null;
+        $row['email_accent_color'] = (string) ($row['email_accent_color'] ?: '#3B2D83');
+        $row['has_email_logo'] = SafeLogoPath::resolve($row['logo_path'] ?? null, $supplierId) !== null;
+
+        return Json::ok($response, $row);
+    }
+
+    private function supplierId(Request $request): int
+    {
+        return (int) $request->getAttribute(SupplierScopeMiddleware::ATTR_CURRENT_ID, 0);
+    }
+
+    private function supplierExists(int $supplierId): bool
+    {
+        $stmt = $this->db->pdo()->prepare('SELECT 1 FROM supplier WHERE id = ?');
+        $stmt->execute([$supplierId]);
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /** @param list<string> $fields */
+    private function log(Request $request, int $supplierId, array $fields): void
+    {
+        $user = (array) $request->getAttribute(AuthMiddleware::ATTR_USER, []);
+        $this->logger->log(
+            'supplier.operational_branding_updated',
+            isset($user['id']) ? (int) $user['id'] : null,
+            'supplier',
+            $supplierId,
+            ['fields' => $fields],
+            $this->ipMatcher->clientIpFromRequest($request->getServerParams()),
+            $request->getHeaderLine('User-Agent'),
+            $supplierId,
+        );
+    }
+}

--- a/api/src/Action/Settings/EmailBrandingAction.php
+++ b/api/src/Action/Settings/EmailBrandingAction.php
@@ -11,6 +11,7 @@ use MyInvoice\Middleware\AuthMiddleware;
 use MyInvoice\Middleware\DemoReadOnlyMiddleware;
 use MyInvoice\Middleware\SupplierScopeMiddleware;
 use MyInvoice\Security\AccessLevel;
+use MyInvoice\Security\OperationalSettingsAccess;
 use MyInvoice\Security\RequestAuthorization;
 use MyInvoice\Service\ActivityLogger;
 use MyInvoice\Service\IpMatcher;
@@ -48,8 +49,8 @@ final class EmailBrandingAction
     /** POST /api/settings/email-branding/logo */
     public function uploadLogo(Request $request, Response $response): Response
     {
-        if (!$this->isAdmin($request)) {
-            return Json::error($response, 'forbidden', 'Pouze admin smí měnit branding.', 403);
+        if (!$this->canManage($request)) {
+            return Json::error($response, 'forbidden', 'Nemáš oprávnění měnit branding.', 403);
         }
 
         $sid = (int) $request->getAttribute(SupplierScopeMiddleware::ATTR_CURRENT_ID, 0);
@@ -117,8 +118,8 @@ final class EmailBrandingAction
     /** DELETE /api/settings/email-branding/logo */
     public function deleteLogo(Request $request, Response $response): Response
     {
-        if (!$this->isAdmin($request)) {
-            return Json::error($response, 'forbidden', 'Pouze admin smí měnit branding.', 403);
+        if (!$this->canManage($request)) {
+            return Json::error($response, 'forbidden', 'Nemáš oprávnění měnit branding.', 403);
         }
         $sid = (int) $request->getAttribute(SupplierScopeMiddleware::ATTR_CURRENT_ID, 0);
         if ($sid <= 0) {
@@ -153,8 +154,8 @@ final class EmailBrandingAction
         // druhá vrstva. Demo smí pouze read-only náhled a logo cesta se validuje níže.
         $demoCanRead = DemoReadOnlyMiddleware::enabled($request)
             && RequestAuthorization::allows($request, 'settings.branding', AccessLevel::READ);
-        if (!$this->isAdmin($request) && !$demoCanRead) {
-            return Json::error($response, 'forbidden', 'Pouze admin smí prohlížet branding.', 403);
+        if (!$this->canManage($request) && !$demoCanRead) {
+            return Json::error($response, 'forbidden', 'Nemáš oprávnění prohlížet branding.', 403);
         }
         $sid = (int) $request->getAttribute(SupplierScopeMiddleware::ATTR_CURRENT_ID, 0);
         if ($sid <= 0) {
@@ -312,9 +313,9 @@ TWIG;
             ->withHeader('Cache-Control', 'no-store');
     }
 
-    private function isAdmin(Request $request): bool
+    private function canManage(Request $request): bool
     {
-        return RequestAuthorization::allows($request, 'settings.branding', AccessLevel::WRITE);
+        return OperationalSettingsAccess::branding($request);
     }
 
     private function defaultProfileId(int $supplierId): ?int

--- a/api/src/Action/Settings/EmailProfilesAction.php
+++ b/api/src/Action/Settings/EmailProfilesAction.php
@@ -10,7 +10,7 @@ use MyInvoice\Infrastructure\Database\Connection;
 use MyInvoice\Middleware\AuthMiddleware;
 use MyInvoice\Middleware\SupplierScopeMiddleware;
 use MyInvoice\Repository\EmailProfileRepository;
-use MyInvoice\Security\AccessLevel;
+use MyInvoice\Security\OperationalSettingsAccess;
 use MyInvoice\Security\RequestAuthorization;
 use MyInvoice\Service\ActivityLogger;
 use MyInvoice\Service\Branding\AccentColor;
@@ -58,21 +58,28 @@ final class EmailProfilesAction
 
     public function list(Request $request, Response $response): Response
     {
-        if (!$this->isAdmin($request)) {
-            return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        if (!$this->canManage($request)) {
+            return Json::error($response, 'forbidden', 'Nemáš oprávnění spravovat e-mailové profily.', 403);
         }
 
-        return Json::ok($response, $this->profiles->listProfiles($this->supplierId($request)));
+        $profiles = array_map(
+            fn (array $profile): array => $this->profileForResponse($request, $profile),
+            $this->profiles->listProfiles($this->supplierId($request)),
+        );
+        return Json::ok($response, $profiles);
     }
 
     public function create(Request $request, Response $response): Response
     {
-        if (!$this->isAdmin($request)) {
-            return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        if (!$this->canManage($request)) {
+            return Json::error($response, 'forbidden', 'Nemáš oprávnění spravovat e-mailové profily.', 403);
         }
 
         $supplierId = $this->supplierId($request);
         $body = (array) ($request->getParsedBody() ?? []);
+        if (($restricted = $this->denyClientRestrictedFields($request, $response, $body)) !== null) {
+            return $restricted;
+        }
         if (($locked = $this->denyCustomTransport($response, $body)) !== null) {
             return $locked;
         }
@@ -104,22 +111,29 @@ final class EmailProfilesAction
             'signing_profile_id' => $profile['signing_profile_id'] ?? null,
         ]);
 
-        return Json::ok($response, $profile, 201);
+        return Json::ok($response, $this->profileForResponse($request, $profile), 201);
     }
 
     public function update(Request $request, Response $response, array $args): Response
     {
-        if (!$this->isAdmin($request)) {
-            return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        if (!$this->canManage($request)) {
+            return Json::error($response, 'forbidden', 'Nemáš oprávnění spravovat e-mailové profily.', 403);
         }
 
         $supplierId = $this->supplierId($request);
         $profileId = (int) ($args['id'] ?? 0);
-        if ($this->profiles->findProfile($supplierId, $profileId) === null) {
+        $current = $this->profiles->findProfile($supplierId, $profileId);
+        if ($current === null) {
             return Json::error($response, 'not_found', 'E-mailový profil nenalezen.', 404);
+        }
+        if (($restricted = $this->denyClientRestrictedProfile($request, $response, $current)) !== null) {
+            return $restricted;
         }
 
         $body = (array) ($request->getParsedBody() ?? []);
+        if (($restricted = $this->denyClientRestrictedFields($request, $response, $body)) !== null) {
+            return $restricted;
+        }
         if (($locked = $this->denyCustomTransport($response, $body)) !== null) {
             return $locked;
         }
@@ -154,13 +168,13 @@ final class EmailProfilesAction
             'signing_profile_id' => $profile['signing_profile_id'] ?? null,
         ]);
 
-        return Json::ok($response, $profile);
+        return Json::ok($response, $this->profileForResponse($request, $profile));
     }
 
     public function test(Request $request, Response $response, array $args): Response
     {
-        if (!$this->isAdmin($request)) {
-            return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        if (!$this->canManage($request)) {
+            return Json::error($response, 'forbidden', 'Nemáš oprávnění spravovat e-mailové profily.', 403);
         }
 
         $supplierId = $this->supplierId($request);
@@ -169,14 +183,17 @@ final class EmailProfilesAction
         if ($profile === null) {
             return Json::error($response, 'not_found', 'E-mailový profil nenalezen.', 404);
         }
+        if (($restricted = $this->denyClientRestrictedProfile($request, $response, $profile)) !== null) {
+            return $restricted;
+        }
 
         return $this->sendProfileTest($request, $response, $profile, $profileId, false);
     }
 
     public function testDraft(Request $request, Response $response): Response
     {
-        if (!$this->isAdmin($request)) {
-            return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        if (!$this->canManage($request)) {
+            return Json::error($response, 'forbidden', 'Nemáš oprávnění spravovat e-mailové profily.', 403);
         }
 
         $supplierId = $this->supplierId($request);
@@ -190,6 +207,9 @@ final class EmailProfilesAction
             ? (array) $body['profile']
             : $body;
         unset($profileData['id'], $profileData['profile_id'], $profileData['profile']);
+        if (($restricted = $this->denyClientRestrictedFields($request, $response, $profileData)) !== null) {
+            return $restricted;
+        }
 
         try {
             $profile = $this->profiles->profileForDraftTest($supplierId, $profileData, $profileId);
@@ -201,14 +221,20 @@ final class EmailProfilesAction
         } catch (\Throwable) {
             return Json::error($response, 'validation_failed', 'Testovací e-mailový profil se nepodařilo připravit.', 400);
         }
+        if (($restricted = $this->denyClientRestrictedProfile($request, $response, $profile)) !== null) {
+            return $restricted;
+        }
 
         return $this->sendProfileTest($request, $response, $profile, $profileId, true);
     }
 
     public function browseImapFolders(Request $request, Response $response, array $args = []): Response
     {
-        if (!$this->isAdmin($request)) {
-            return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        if (!$this->canManage($request)) {
+            return Json::error($response, 'forbidden', 'Nemáš oprávnění spravovat e-mailové profily.', 403);
+        }
+        if (($restricted = $this->denyClientRestrictedImapProfile($request, $response, $args)) !== null) {
+            return $restricted;
         }
 
         try {
@@ -225,8 +251,11 @@ final class EmailProfilesAction
 
     public function testImapSettings(Request $request, Response $response, array $args = []): Response
     {
-        if (!$this->isAdmin($request)) {
-            return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        if (!$this->canManage($request)) {
+            return Json::error($response, 'forbidden', 'Nemáš oprávnění spravovat e-mailové profily.', 403);
+        }
+        if (($restricted = $this->denyClientRestrictedImapProfile($request, $response, $args)) !== null) {
+            return $restricted;
         }
 
         try {
@@ -247,14 +276,8 @@ final class EmailProfilesAction
     private function imapProbeSettings(Request $request, array $args = []): array
     {
         $supplierId = $this->supplierId($request);
-        $profileId = isset($args['id']) ? (int) $args['id'] : null;
+        $profileId = $this->imapProfileId($request, $args);
         $body = (array) ($request->getParsedBody() ?? []);
-        if ($profileId === null && isset($body['id']) && (int) $body['id'] > 0) {
-            $profileId = (int) $body['id'];
-        }
-        if ($profileId === null && isset($body['profile_id']) && (int) $body['profile_id'] > 0) {
-            $profileId = (int) $body['profile_id'];
-        }
 
         $profileData = isset($body['profile']) && is_array($body['profile'])
             ? (array) $body['profile']
@@ -266,19 +289,37 @@ final class EmailProfilesAction
 
     private function imapProbeError(Request $request, Response $response, array $args, \InvalidArgumentException $e): Response
     {
-        $body = (array) ($request->getParsedBody() ?? []);
-        $profileId = isset($args['id']) ? (int) $args['id'] : null;
-        if ($profileId === null && isset($body['id']) && (int) $body['id'] > 0) {
-            $profileId = (int) $body['id'];
-        }
-        if ($profileId === null && isset($body['profile_id']) && (int) $body['profile_id'] > 0) {
-            $profileId = (int) $body['profile_id'];
-        }
+        $profileId = $this->imapProfileId($request, $args);
         if ($profileId !== null && $this->profiles->findProfile($this->supplierId($request), $profileId) === null) {
             return Json::error($response, 'not_found', 'E-mailový profil nenalezen.', 404);
         }
 
         return Json::error($response, 'validation_failed', $e->getMessage(), 400);
+    }
+
+    private function denyClientRestrictedImapProfile(
+        Request $request,
+        Response $response,
+        array $args,
+    ): ?Response {
+        if (!RequestAuthorization::isClientType($request)) return null;
+
+        $profileId = $this->imapProfileId($request, $args);
+        if ($profileId === null) return null;
+        $profile = $this->profiles->findProfile($this->supplierId($request), $profileId);
+        if ($profile === null) return null;
+
+        return $this->denyClientRestrictedProfile($request, $response, $profile);
+    }
+
+    private function imapProfileId(Request $request, array $args): ?int
+    {
+        if (isset($args['id']) && (int) $args['id'] > 0) return (int) $args['id'];
+
+        $body = (array) ($request->getParsedBody() ?? []);
+        if (isset($body['id']) && (int) $body['id'] > 0) return (int) $body['id'];
+        if (isset($body['profile_id']) && (int) $body['profile_id'] > 0) return (int) $body['profile_id'];
+        return null;
     }
 
     /**
@@ -356,8 +397,8 @@ final class EmailProfilesAction
 
     public function delete(Request $request, Response $response, array $args): Response
     {
-        if (!$this->isAdmin($request)) {
-            return Json::error($response, 'forbidden', 'Pouze admin.', 403);
+        if (!$this->canManage($request)) {
+            return Json::error($response, 'forbidden', 'Nemáš oprávnění spravovat e-mailové profily.', 403);
         }
 
         $supplierId = $this->supplierId($request);
@@ -365,6 +406,9 @@ final class EmailProfilesAction
         $profile = $this->profiles->findProfile($supplierId, $profileId);
         if ($profile === null) {
             return Json::error($response, 'not_found', 'E-mailový profil nenalezen.', 404);
+        }
+        if (($restricted = $this->denyClientRestrictedProfile($request, $response, $profile)) !== null) {
+            return $restricted;
         }
 
         $brandingNames = $this->profiles->brandingProfileUsages($supplierId, $profileId);
@@ -392,9 +436,83 @@ final class EmailProfilesAction
         return isset($user['id']) ? (int) $user['id'] : null;
     }
 
-    private function isAdmin(Request $request): bool
+    private function canManage(Request $request): bool
     {
-        return RequestAuthorization::allows($request, 'settings.company.write', AccessLevel::WRITE);
+        return OperationalSettingsAccess::emailProfiles($request);
+    }
+
+    /**
+     * Elektronické podpisy a lokální sendmail nejsou součástí klientsky
+     * delegovaného nastavení. Kontrola je v akci, ne jen ve formuláři.
+     *
+     * @param array<string,mixed> $body
+     */
+    private function denyClientRestrictedFields(Request $request, Response $response, array $body): ?Response
+    {
+        if (!RequestAuthorization::isClientType($request)) return null;
+
+        if (array_key_exists('signing_profile_id', $body)) {
+            return Json::error(
+                $response,
+                'field_not_delegable',
+                'Elektronické podepisování není součástí delegovaného nastavení firmy.',
+                403,
+            );
+        }
+        if (array_key_exists('sendmail_command', $body)
+            || strtolower(trim((string) ($body['transport_type'] ?? ''))) === 'sendmail'
+        ) {
+            return Json::error(
+                $response,
+                'field_not_delegable',
+                'Lokální sendmail není součástí delegovaného nastavení firmy.',
+                403,
+            );
+        }
+        return null;
+    }
+
+    /**
+     * Profily napojené na systémový sendmail nebo kryptografické S/MIME identity
+     * zůstávají ve správě staff role. Klient je vidí v seznamu, ale nemůže je
+     * testovat, měnit ani smazat.
+     *
+     * @param array<string,mixed> $profile
+     */
+    private function denyClientRestrictedProfile(Request $request, Response $response, array $profile): ?Response
+    {
+        if (!RequestAuthorization::isClientType($request)) return null;
+
+        if (($profile['signing_profile_id'] ?? null) !== null
+            || strtolower((string) ($profile['transport_type'] ?? 'global')) === 'sendmail'
+        ) {
+            return Json::error(
+                $response,
+                'profile_not_delegable',
+                'Tento pokročilý e-mailový profil může spravovat pouze správce instalace.',
+                403,
+            );
+        }
+        return null;
+    }
+
+    /**
+     * @param array<string,mixed>|null $profile
+     * @return array<string,mixed>|null
+     */
+    private function profileForResponse(Request $request, ?array $profile): ?array
+    {
+        if ($profile === null || !RequestAuthorization::isClientType($request)) return $profile;
+
+        $profile['client_manageable'] = ($profile['signing_profile_id'] ?? null) === null
+            && strtolower((string) ($profile['transport_type'] ?? 'global')) !== 'sendmail';
+        unset(
+            $profile['signing_profile_id'],
+            $profile['signing_profile_name'],
+            $profile['signing_profile_code'],
+            $profile['sendmail_command'],
+        );
+        return $profile;
     }
 
     /**

--- a/api/src/Repository/BrandingProfileRepository.php
+++ b/api/src/Repository/BrandingProfileRepository.php
@@ -78,6 +78,16 @@ final class BrandingProfileRepository
         return $row === false ? null : $this->cast($row);
     }
 
+    public function hasActiveEmailProfile(int $supplierId, int $emailProfileId): bool
+    {
+        $stmt = $this->db->pdo()->prepare(
+            'SELECT 1 FROM email_profiles
+              WHERE supplier_id = ? AND id = ? AND deleted_at IS NULL AND is_active = 1'
+        );
+        $stmt->execute([$supplierId, $emailProfileId]);
+        return $stmt->fetchColumn() !== false;
+    }
+
     public function create(int $supplierId, array $data): int
     {
         $normalized = $this->normalize($data);

--- a/api/src/Routes.php
+++ b/api/src/Routes.php
@@ -62,6 +62,7 @@ use MyInvoice\Action\Admin\RoleAdminAction;
 use MyInvoice\Action\Admin\SupplierSearchAction;
 use MyInvoice\Action\Settings\EmailBrandingAction;
 use MyInvoice\Action\Settings\BrandingProfilesAction;
+use MyInvoice\Action\Settings\ClientBrandingSettingsAction;
 use MyInvoice\Action\Settings\EmailProfilesAction;
 use MyInvoice\Action\Settings\PdfSigningDiagnosticsAction;
 use MyInvoice\Action\Settings\SettingsAction;
@@ -2087,6 +2088,30 @@ final class Routes
         $app->post   ('/api/settings/email-profiles/{id:[0-9]+}/folders', [EmailProfilesAction::class, 'browseImapFolders']);
         $app->put    ('/api/settings/email-profiles/{id:[0-9]+}', [EmailProfilesAction::class, 'update']);
         $app->delete ('/api/settings/email-profiles/{id:[0-9]+}', [EmailProfilesAction::class, 'delete']);
+        // Klientský allowlist používá stejné supplier-scoped akce, ale vlastní URL.
+        // RoutePermissionMap na těchto aliasových cestách vyžaduje settings.company WRITE.
+        $app->get    ('/api/settings/client/email-profiles',       [EmailProfilesAction::class, 'list']);
+        $app->post   ('/api/settings/client/email-profiles',       [EmailProfilesAction::class, 'create']);
+        $app->post   ('/api/settings/client/email-profiles/test',  [EmailProfilesAction::class, 'testDraft']);
+        $app->post   ('/api/settings/client/email-profiles/imap-test', [EmailProfilesAction::class, 'testImapSettings']);
+        $app->post   ('/api/settings/client/email-profiles/folders', [EmailProfilesAction::class, 'browseImapFolders']);
+        $app->post   ('/api/settings/client/email-profiles/{id:[0-9]+}/test', [EmailProfilesAction::class, 'test']);
+        $app->post   ('/api/settings/client/email-profiles/{id:[0-9]+}/imap-test', [EmailProfilesAction::class, 'testImapSettings']);
+        $app->post   ('/api/settings/client/email-profiles/{id:[0-9]+}/folders', [EmailProfilesAction::class, 'browseImapFolders']);
+        $app->put    ('/api/settings/client/email-profiles/{id:[0-9]+}', [EmailProfilesAction::class, 'update']);
+        $app->delete ('/api/settings/client/email-profiles/{id:[0-9]+}', [EmailProfilesAction::class, 'delete']);
+        $app->get    ('/api/settings/client/branding', [ClientBrandingSettingsAction::class, 'get']);
+        $app->put    ('/api/settings/client/branding', [ClientBrandingSettingsAction::class, 'update']);
+        $app->get    ('/api/settings/client/branding/preview', [EmailBrandingAction::class, 'preview']);
+        $app->post   ('/api/settings/client/branding/logo', [EmailBrandingAction::class, 'uploadLogo']);
+        $app->delete ('/api/settings/client/branding/logo', [EmailBrandingAction::class, 'deleteLogo']);
+        $app->get    ('/api/settings/client/branding/profiles', [BrandingProfilesAction::class, 'list']);
+        $app->post   ('/api/settings/client/branding/profiles', [BrandingProfilesAction::class, 'create']);
+        $app->put    ('/api/settings/client/branding/profiles/{id:[0-9]+}', [BrandingProfilesAction::class, 'update']);
+        $app->delete ('/api/settings/client/branding/profiles/{id:[0-9]+}', [BrandingProfilesAction::class, 'delete']);
+        $app->post   ('/api/settings/client/branding/profiles/{id:[0-9]+}/default', [BrandingProfilesAction::class, 'setDefault']);
+        $app->post   ('/api/settings/client/branding/profiles/{id:[0-9]+}/logo', [BrandingProfilesAction::class, 'uploadLogo']);
+        $app->delete ('/api/settings/client/branding/profiles/{id:[0-9]+}/logo', [BrandingProfilesAction::class, 'deleteLogo']);
         $app->get    ('/api/settings/branding-profiles',                 [BrandingProfilesAction::class, 'list']);
         $app->post   ('/api/settings/branding-profiles',                 [BrandingProfilesAction::class, 'create']);
         $app->put    ('/api/settings/branding-profiles/{id:[0-9]+}',     [BrandingProfilesAction::class, 'update']);

--- a/api/src/Security/OperationalSettingsAccess.php
+++ b/api/src/Security/OperationalSettingsAccess.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Security;
+
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * Autorizační SSOT pro provozní nastavení delegovatelná klientovi.
+ *
+ * Klientská role používá existující `settings.company` na úrovni WRITE. Široké
+ * `settings.company.write` zůstává výhradně interním rolím, protože otevírá i
+ * daňové, účetní a právně významné údaje firmy.
+ */
+final class OperationalSettingsAccess
+{
+    public static function emailProfiles(Request $request): bool
+    {
+        if (RequestAuthorization::isClientType($request)) {
+            return self::clientCompanyWrite($request);
+        }
+        return RequestAuthorization::allows($request, 'settings.company.write', AccessLevel::WRITE);
+    }
+
+    public static function branding(Request $request): bool
+    {
+        if (RequestAuthorization::isClientType($request)) {
+            return self::clientCompanyWrite($request);
+        }
+        return RequestAuthorization::allows($request, 'settings.branding', AccessLevel::WRITE);
+    }
+
+    public static function clientCompanyWrite(Request $request): bool
+    {
+        return RequestAuthorization::isClientType($request)
+            && RequestAuthorization::allows($request, 'settings.company', AccessLevel::WRITE);
+    }
+}

--- a/api/src/Security/PermissionCatalog.php
+++ b/api/src/Security/PermissionCatalog.php
@@ -6,7 +6,7 @@ namespace MyInvoice\Security;
 
 final class PermissionCatalog
 {
-    public const VERSION = '2026-08-domains-document-submissions-v1';
+    public const VERSION = '2026-08-client-company-settings-v1';
 
     /** @var list<string> */
     private const GROUPS = [
@@ -150,9 +150,11 @@ final class PermissionCatalog
                 'key' => $key,
                 'group' => $group,
                 'label' => $label,
-                'description' => str_contains($key, '.')
-                    ? 'Povoluje akci „' . $label . '“.'
-                    : 'Zpřístupňuje modul „' . $label . '“.',
+                'description' => $key === 'settings.company'
+                    ? 'Čtení zpřístupní firemní kontext; zápis klientské roli otevře pouze delegované provozní nastavení (odesílací profily a branding), nikoli daňové ani právní údaje.'
+                    : (str_contains($key, '.')
+                        ? 'Povoluje akci „' . $label . '“.'
+                        : 'Zpřístupňuje modul „' . $label . '“.'),
                 'role_types' => $types,
                 'kind' => str_contains($key, '.') ? 'action' : 'module',
             ];

--- a/api/src/Security/RoutePermissionMap.php
+++ b/api/src/Security/RoutePermissionMap.php
@@ -51,6 +51,10 @@ final class RoutePermissionMap
      * @var list<array{0:string,1:string,2:string,3:AccessLevel}>
      */
     private const RULES = [
+        // Přesný allowlist provozních nastavení delegovatelných klientovi. Musí být
+        // před obecným /api/settings fallbackem: `settings.company = WRITE` nikdy
+        // nesmí otevřít PUT /api/settings/supplier ani účetní/daňové konfigurace.
+        ['*', '#^/api/settings/client/(email-profiles|branding)(/|$)#', 'settings.company', AccessLevel::WRITE],
         ['GET', '#^/api/settings/domains(/|$)#', 'settings.domains', AccessLevel::READ],
         ['*', '#^/api/settings/domains(/|$)#', 'settings.domains', AccessLevel::WRITE],
         ['GET', '#^/api/auth/tokens(/|$)#', 'profile.tokens', AccessLevel::READ],

--- a/api/tests/Integration/RbacHttpRoleMatrixTest.php
+++ b/api/tests/Integration/RbacHttpRoleMatrixTest.php
@@ -32,6 +32,8 @@ final class RbacHttpRoleMatrixTest extends TestCase
     private array $roleIds = [];
     /** @var list<int> */
     private array $clientIds = [];
+    /** @var list<int> */
+    private array $emailProfileIds = [];
     /** @var list<string> */
     private array $sessionTokens = [];
 
@@ -58,6 +60,10 @@ final class RbacHttpRoleMatrixTest extends TestCase
         $pdo = $this->db->pdo();
         foreach ($this->sessionTokens as $token) {
             try { $this->sessions->destroy($token); } catch (\Throwable) {}
+        }
+        if ($this->emailProfileIds !== []) {
+            $placeholders = implode(',', array_fill(0, count($this->emailProfileIds), '?'));
+            $pdo->prepare("DELETE FROM email_profiles WHERE id IN ({$placeholders})")->execute($this->emailProfileIds);
         }
         if ($this->clientIds !== []) {
             $placeholders = implode(',', array_fill(0, count($this->clientIds), '?'));
@@ -101,6 +107,9 @@ final class RbacHttpRoleMatrixTest extends TestCase
         $staffModuleAllowed = $tenantBaseAllowed && ($roleType === 'staff' || $isSuperadmin);
         $clientModuleAllowed = $tenantBaseAllowed;
         $writeAllowed = $tenantBaseAllowed && $level === 2;
+        $staffSettingsWriteAllowed = $tenantBaseAllowed
+            && $level === 2
+            && ($roleType === 'staff' || $isSuperadmin);
 
         foreach ([
             ['GET', '/api/invoices', null, $clientModuleAllowed],
@@ -110,6 +119,9 @@ final class RbacHttpRoleMatrixTest extends TestCase
             ['GET', '/api/accounting/journal', null, $staffModuleAllowed],
             ['GET', '/api/reports/dph-book?year=2025', null, $staffModuleAllowed],
             ['GET', '/api/settings/supplier', null, $clientModuleAllowed],
+            ['GET', '/api/settings/client/email-profiles', null, $writeAllowed],
+            ['GET', '/api/settings/client/branding', null, $writeAllowed],
+            ['PUT', '/api/settings/supplier', [], $staffSettingsWriteAllowed],
             ['POST', '/api/invoices/999999/send', [], $writeAllowed],
             ['POST', '/api/purchase-invoices', [], $writeAllowed],
         ] as [$method, $path, $body, $allowed]) {
@@ -135,6 +147,67 @@ final class RbacHttpRoleMatrixTest extends TestCase
         }
     }
 
+    public function testClientCompanyWriteUsesOnlyTheOperationalSettingsAllowlist(): void
+    {
+        $readerId = $this->createUser('client_operational_settings_read', 'client', 1, true);
+        $readerSession = $this->createSession($readerId);
+        $readerProfiles = $this->request('GET', '/api/settings/branding-profiles', $readerSession);
+        self::assertSame(403, $readerProfiles->getStatusCode());
+        self::assertSame('forbidden', $this->json($readerProfiles)['error']['code'] ?? null);
+
+        $userId = $this->createUser('client_operational_settings', 'client', 2, true);
+        $session = $this->createSession($userId);
+        $secret = '__TEST_SMTP_SECRET_' . bin2hex(random_bytes(8));
+        $code = 'client-' . bin2hex(random_bytes(5));
+
+        $created = $this->request('POST', '/api/settings/client/email-profiles', $session, [
+            'name' => '__TEST client delegated profile',
+            'code' => $code,
+            'from_email' => 'delegated@example.test',
+            'transport_type' => 'global',
+            'smtp_password' => $secret,
+            'is_default' => false,
+            'is_active' => true,
+        ]);
+        self::assertSame(201, $created->getStatusCode(), (string) $created->getBody());
+        $createdBody = $this->json($created);
+        $profileId = (int) ($createdBody['id'] ?? 0);
+        self::assertGreaterThan(0, $profileId);
+        $this->emailProfileIds[] = $profileId;
+        self::assertArrayNotHasKey('smtp_password', $createdBody);
+        self::assertArrayNotHasKey('imap_password', $createdBody);
+        self::assertArrayNotHasKey('signing_profile_id', $createdBody);
+        self::assertTrue($createdBody['client_manageable'] ?? false);
+
+        $audit = $this->db->pdo()->prepare(
+            'SELECT payload FROM activity_log WHERE user_id = ? AND action = ? ORDER BY id DESC LIMIT 1'
+        );
+        $audit->execute([$userId, 'email_profile.created']);
+        self::assertStringNotContainsString($secret, (string) $audit->fetchColumn());
+
+        $sendmail = $this->request('POST', '/api/settings/client/email-profiles', $session, [
+            'name' => '__TEST forbidden sendmail',
+            'code' => $code . '-sendmail',
+            'from_email' => 'delegated@example.test',
+            'transport_type' => 'sendmail',
+            'sendmail_command' => '/usr/sbin/sendmail -bs',
+        ]);
+        self::assertSame(403, $sendmail->getStatusCode());
+        self::assertSame('field_not_delegable', $this->json($sendmail)['error']['code'] ?? null);
+
+        $broad = $this->request('PUT', '/api/settings/supplier', $session, [
+            'company_name' => '__TEST forbidden legal change',
+        ]);
+        self::assertSame(403, $broad->getStatusCode());
+        self::assertSame('forbidden_permission', $this->json($broad)['error']['code'] ?? null);
+
+        $brandingMassAssignment = $this->request('PUT', '/api/settings/client/branding', $session, [
+            'company_name' => '__TEST forbidden branding change',
+        ]);
+        self::assertSame(403, $brandingMassAssignment->getStatusCode());
+        self::assertSame('field_not_delegable', $this->json($brandingMassAssignment)['error']['code'] ?? null);
+    }
+
     private function createUser(string $variant, string $roleType, int $level, bool $hasSupplier): int
     {
         if ($variant === 'superadmin') {
@@ -146,7 +219,7 @@ final class RbacHttpRoleMatrixTest extends TestCase
             $this->roleIds[] = $roleId;
             $keys = $roleType === 'client'
                 ? ['clients', 'clients.create', 'invoices', 'invoices.send', 'purchase_invoices', 'purchase_invoices.create', 'settings.company']
-                : ['clients', 'clients.create', 'invoices', 'invoices.send', 'purchase_invoices', 'purchase_invoices.create', 'documents', 'bank', 'accounting', 'reports', 'settings.company'];
+                : ['clients', 'clients.create', 'invoices', 'invoices.send', 'purchase_invoices', 'purchase_invoices.create', 'documents', 'bank', 'accounting', 'reports', 'settings.company', 'settings.company.write', 'settings.branding'];
             $insert = $this->db->pdo()->prepare('INSERT INTO role_permissions (role_id, permission_key, access_level) VALUES (?, ?, ?)');
             foreach ($keys as $key) $insert->execute([$roleId, $key, $level]);
         }

--- a/api/tests/Unit/Security/OperationalSettingsAccessTest.php
+++ b/api/tests/Unit/Security/OperationalSettingsAccessTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Security;
+
+use MyInvoice\Security\AccessLevel;
+use MyInvoice\Security\EffectiveRole;
+use MyInvoice\Security\OperationalSettingsAccess;
+use PHPUnit\Framework\TestCase;
+use Slim\Psr7\Factory\ServerRequestFactory;
+
+final class OperationalSettingsAccessTest extends TestCase
+{
+    public function testClientNeedsCompanyWriteForBothDelegatedAreas(): void
+    {
+        $reader = $this->request(new EffectiveRole(4, 'Klient', 'client', true, [
+            'settings.company' => AccessLevel::READ->value,
+        ]));
+        self::assertFalse(OperationalSettingsAccess::emailProfiles($reader));
+        self::assertFalse(OperationalSettingsAccess::branding($reader));
+
+        $writer = $this->request(new EffectiveRole(4, 'Klient', 'client', true, [
+            'settings.company' => AccessLevel::WRITE->value,
+        ]));
+        self::assertTrue(OperationalSettingsAccess::emailProfiles($writer));
+        self::assertTrue(OperationalSettingsAccess::branding($writer));
+    }
+
+    public function testClientCannotSubstituteStaffOnlyPermissions(): void
+    {
+        $request = $this->request(new EffectiveRole(4, 'Klient', 'client', true, [
+            'settings.company' => AccessLevel::READ->value,
+            'settings.company.write' => AccessLevel::WRITE->value,
+            'settings.branding' => AccessLevel::WRITE->value,
+        ]));
+
+        self::assertFalse(OperationalSettingsAccess::emailProfiles($request));
+        self::assertFalse(OperationalSettingsAccess::branding($request));
+    }
+
+    public function testStaffAndSuperadminKeepTheirExistingPermissions(): void
+    {
+        $staff = $this->request(new EffectiveRole(2, 'Správce', 'staff', true, [
+            'settings.company.write' => AccessLevel::WRITE->value,
+            'settings.branding' => AccessLevel::WRITE->value,
+        ]));
+        self::assertTrue(OperationalSettingsAccess::emailProfiles($staff));
+        self::assertTrue(OperationalSettingsAccess::branding($staff));
+
+        $superadmin = $this->request(new EffectiveRole(1, 'Superadmin', 'superadmin', true, [], 'superadmin'));
+        self::assertTrue(OperationalSettingsAccess::emailProfiles($superadmin));
+        self::assertTrue(OperationalSettingsAccess::branding($superadmin));
+    }
+
+    private function request(EffectiveRole $role): \Psr\Http\Message\ServerRequestInterface
+    {
+        return (new ServerRequestFactory())
+            ->createServerRequest('GET', '/api/settings/client/branding')
+            ->withAttribute('auth.effective_role', $role);
+    }
+}

--- a/api/tests/Unit/Security/RoutePermissionMapTest.php
+++ b/api/tests/Unit/Security/RoutePermissionMapTest.php
@@ -63,6 +63,16 @@ final class RoutePermissionMapTest extends TestCase
             ['POST', '/api/settings/currencies', 'settings.bank_accounts', AccessLevel::WRITE],
             ['GET', '/api/settings/email-branding/preview', 'settings.branding', AccessLevel::READ],
             ['POST', '/api/settings/email-branding/logo', 'settings.branding', AccessLevel::WRITE],
+            // Klientsky delegovatelná provozní nastavení mají vlastní přesný allowlist.
+            // Nikdy nesmí propadnout na široké settings.company.write, které otevírá
+            // i daňové, účetní a právně významné údaje dodavatele.
+            ['GET', '/api/settings/client/email-profiles', 'settings.company', AccessLevel::WRITE],
+            ['POST', '/api/settings/client/email-profiles', 'settings.company', AccessLevel::WRITE],
+            ['POST', '/api/settings/client/email-profiles/7/imap-test', 'settings.company', AccessLevel::WRITE],
+            ['GET', '/api/settings/client/branding', 'settings.company', AccessLevel::WRITE],
+            ['PUT', '/api/settings/client/branding', 'settings.company', AccessLevel::WRITE],
+            ['POST', '/api/settings/client/branding/profiles/7/logo', 'settings.company', AccessLevel::WRITE],
+            ['PUT', '/api/settings/supplier', 'settings.company.write', AccessLevel::WRITE],
             ['GET', '/api/settings/accounting-activation/status', 'settings.company', AccessLevel::READ],
             ['POST', '/api/settings/accounting-activation/start', 'accounting.periods.manage', AccessLevel::WRITE],
             ['GET', '/api/price-list-items', 'invoices', AccessLevel::READ],

--- a/api/tests/Unit/Service/Tenant/ClientRoutePolicyTest.php
+++ b/api/tests/Unit/Service/Tenant/ClientRoutePolicyTest.php
@@ -24,9 +24,9 @@ final class ClientRoutePolicyTest extends TestCase
         $names = array_column($routes, 'name');
         $patterns = array_column($routes, 'path_pattern');
 
-        self::assertCount(36, $routes);
-        self::assertCount(36, array_unique($names));
-        self::assertCount(36, array_unique($patterns));
+        self::assertCount(37, $routes);
+        self::assertCount(37, array_unique($names));
+        self::assertCount(37, array_unique($patterns));
         self::assertContains('data-exchange', $names);
         self::assertContains('admin-export', $names);
         self::assertContains('admin-import', $names);
@@ -58,6 +58,7 @@ final class ClientRoutePolicyTest extends TestCase
             '/portal',
             '/portal/document-requests',
             '/portal/purchase-invoice-submissions',
+            '/portal/settings',
             '/clients',
             '/clients/new',
             '/clients/42',
@@ -200,6 +201,10 @@ final class ClientRoutePolicyTest extends TestCase
             ['POST', '/api/purchase-invoices/7/transition'],
             ['POST', '/api/recurring/7/run'],
             ['GET', '/api/settings'],
+            ['GET', '/api/settings/client/email-profiles'],
+            ['POST', '/api/settings/client/email-profiles'],
+            ['PUT', '/api/settings/client/branding'],
+            ['POST', '/api/settings/client/branding/profiles/7/logo'],
             ['PUT', '/api/user/preferences/navigation'],
         ] as [$method, $path]) {
             self::assertTrue($this->policy->allowsApiRequest($method, $path), "$method $path");
@@ -223,6 +228,9 @@ final class ClientRoutePolicyTest extends TestCase
             ['POST', '/api/admin/import'],
             ['GET', '/api/auth/tokens'],
             ['POST', '/api/settings'],
+            ['PUT', '/api/settings/supplier'],
+            ['POST', '/api/settings/email-profiles'],
+            ['POST', '/api/settings/email-branding/logo'],
         ] as [$method, $path]) {
             self::assertFalse($this->policy->allowsApiRequest($method, $path), "$method $path");
         }

--- a/manual/09_Klientsky_portal.md
+++ b/manual/09_Klientsky_portal.md
@@ -13,7 +13,8 @@ které se po zaúčtování uzamknou proti dalším úpravám.
 > Client je naopak externí osoba (majitel firmy, na kterou účetní vede agendu),
 > která **smí vystavovat a upravovat vlastní doklady**, ale nevidí nic z účetnictví,
 > banky, reportů ani nastavení systému a nemůže sáhnout na doklad, který už účetní
-> zaúčtovala.
+> zaúčtovala. Vybrané provozní nastavení vlastní firmy dostane pouze tehdy, když
+> má jeho klientská role oprávnění **Nastavení firmy** na úrovni **Zápis**.
 
 ## 9.1 Kdo roli client dostane a jak
 
@@ -39,7 +40,7 @@ Uživatelé** (stejný formulář jako u ostatních rolí, viz [§ 92.2 Uživate
 
 ## 9.2 Menu klienta — jen zlomek aplikace
 
-Po přihlášení nabídne menu klientovi jen pět sekcí: **Přehled**
+Po přihlášení nabídne menu běžnému klientovi pět sekcí: **Přehled**
 (portál, domovská stránka), **Prodej** (vydané faktury + pravidelná fakturace),
 **Nákup** (přijaté faktury), **Kontakty** (klienti/dodavatelé) a **Dokumenty**
 s položkami **Předat doklady účetní** a **Chybějící doklady**
@@ -47,7 +48,7 @@ s položkami **Předat doklady účetní** a **Chybějící doklady**
 Na desktopu jsou sekce v horní liště s popup položkami, na mobilu v nabídce
 **☰**. Nápovědu otevírá kontextová ikona **?** v horní liště.
 Cokoliv jiného v aplikaci existuje — účetnictví, banka, sklad, e-shop, reporty,
-Grafy, kniha jízd, DMS dokumenty, nastavení, administrace uživatelů — klient v menu
+Grafy, kniha jízd, DMS dokumenty, systémové nastavení, administrace uživatelů — klient v menu
 vůbec nevidí a při pokusu dostat se tam přímo přes adresu URL ho systém přesměruje
 zpátky na portál. Toto omezení je vynucené na dvou místech zároveň (frontend
 i API), takže ho nejde obejít ani ruční úpravou adresy v prohlížeči.
@@ -69,6 +70,33 @@ například **platební příkazy** (bankovní ABO/KPC soubory a ověřování �
 e-mailové schránky účetní**, **zakázky** ani **DMS dokumenty** k přijatým fakturám.
 Sklad a e-shop, daňová evidence, účetní deník a bankovní výpisy jsou pro klienta
 zavřené úplně.
+
+### 9.2.1 Delegované nastavení firmy
+
+Samostatná role **Client Admin** není potřeba. Superadmin může vytvořit nebo
+duplikovat běžnou roli typu **client** a u položky **Nastavení firmy** zvolit
+**Zápis**. Klient pak v nové sekci **Firma → Nastavení firmy** spravuje pouze
+výslovně povolené provozní oblasti aktuální firmy:
+
+- odesílací profily, odesílatele, Reply-To, DKIM a supplier-scoped SMTP/IMAP,
+- branding komunikace, logo, barvy, patičky a brandingové profily.
+
+Úroveň **Pouze čtení** tuto sekci nezobrazí. Zápis zároveň neotevře původní
+administrátorskou stránku nastavení ani obecný endpoint dodavatele. Klient proto
+nemůže měnit obchodní jméno, IČ, DIČ, bankovní účty, číslování dokladů, DPH,
+účetní režim, integrace, přístupové údaje AI, uživatele ani role. Systémový `sendmail`
+a profily s kryptografickým S/MIME podpisem zůstávají ve správě administrátora.
+
+SMTP a IMAP hesla se po uložení už nikdy nevracejí do prohlížeče; rozhraní ukáže
+jen informaci, zda je heslo nastavené. Změny i testovací odeslání se zapisují do
+historie akcí bez tajných hodnot a požadavky podléhají stejnému rate limitu jako
+ostatní mutace. Všechny operace používají firmu z ověřeného kontextu — ID firmy
+zaslané v těle požadavku rozsah nerozšíří.
+
+Roli lze přiřadit jako přepis jen u jedné firmy. Tentýž uživatel tak může mít ve
+firmě A klientskou roli s **Nastavení firmy = Zápis**, zatímco ve firmě B zůstane
+u běžné klientské role. Po přepnutí firmy se menu i oprávnění ihned přepočítají;
+stejně se chová klientská vlastní doména.
 
 ## 9.3 Co portál (Přehled) zobrazuje
 

--- a/manual/92_Nastaveni.md
+++ b/manual/92_Nastaveni.md
@@ -237,6 +237,14 @@ pro klientský portál; interní účetnictví, banka a globální správa se ji
 nepovolí. Systémová role **Superadmin** je uzamčená, nelze ji deaktivovat,
 smazat ani upravit její matici a jako jediná smí spravovat uživatele a role.
 
+U klientské role má položka **Nastavení firmy** záměrně užší význam než interní
+právo **Měnit nastavení firmy**. Úroveň **Zápis** otevře v klientském menu pouze
+supplier-scoped odesílací profily a branding; neotevře právní, daňové ani účetní
+údaje dodavatele. Díky přepisu role u konkrétní firmy lze stejného uživatele
+nechat spravovat provozní nastavení firmy A a ve firmě B mu ponechat běžný
+klientský přístup. Podrobný rozsah popisuje
+[§ 9.2.1 Delegované nastavení firmy](09_Klientsky_portal.md#921-delegovane-nastaveni-firmy).
+
 Předávání originálů používá záměrně oddělená práva. Klientské
 **Předávat doklady účetní** dovolí pouze vložit a sledovat vlastní podání aktuální
 firmy. Interní **Příchozí doklady** dovolí účetní frontu číst nebo zpracovávat —

--- a/web/shared/client-route-policy.json
+++ b/web/shared/client-route-policy.json
@@ -5,6 +5,7 @@
     { "name": "portal", "path_pattern": "^/portal/?$", "kind": "permission", "permission": "profile", "access": "read" },
     { "name": "portal-document-requests", "path_pattern": "^/portal/document-requests/?$", "kind": "permission", "permission": "documents.submit", "access": "read" },
     { "name": "portal-purchase-invoice-submissions", "path_pattern": "^/portal/purchase-invoice-submissions/?$", "kind": "permission", "permission": "documents.submit", "access": "read" },
+    { "name": "portal-company-settings", "path_pattern": "^/portal/settings/?$", "kind": "permission", "permission": "settings.company", "access": "write" },
 
     { "name": "clients", "path_pattern": "^/clients/?$", "kind": "permission", "permission": "clients", "access": "read" },
     { "name": "client-new", "path_pattern": "^/clients/new/?$", "kind": "permission", "permission": "clients.create", "access": "write" },

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -297,6 +297,23 @@ export interface BrandingProfile {
   is_default: boolean
 }
 
+/** Úzký supplier-scoped výřez, který lze delegovat klientské roli. */
+export interface OperationalBrandingSettings {
+  id: number
+  company_name: string
+  display_name: string | null
+  email: string | null
+  phone: string | null
+  web: string | null
+  tagline: string | null
+  email_branding_enabled: boolean
+  email_accent_color: string
+  pdf_logo_show_name: boolean
+  branding_profiles_enabled: boolean
+  logo_path: string | null
+  has_email_logo?: boolean
+}
+
 export interface CurrencyAccount {
   id: number
   code: string
@@ -592,6 +609,8 @@ export interface EmailProfile {
   created_at: string
   updated_at: string
   deleted_at: string | null
+  /** false jen v klientském allowlistu pro sendmail/S/MIME profil spravovaný staff rolí. */
+  client_manageable?: boolean
 }
 
 export interface EmailProfilePayload {
@@ -789,6 +808,9 @@ export interface PdfSignatureOutputSettingsBatchResult {
 export const settingsApi = {
   getSupplier: () => api.get<Supplier>('/settings/supplier').then(r => r.data),
   updateSupplier: (payload: Partial<Supplier>) => api.put<Supplier>('/settings/supplier', payload).then(r => r.data),
+  getClientBranding: () => api.get<OperationalBrandingSettings>('/settings/client/branding').then(r => r.data),
+  updateClientBranding: (payload: Partial<OperationalBrandingSettings>) =>
+    api.put<OperationalBrandingSettings>('/settings/client/branding', payload).then(r => r.data),
   // E2: při total > 0 přesměruje FE do průvodce; přímé uložení jistí BE 409 backfill_required.
   getModeSwitchPreview: () => api.get<ModeSwitchPreview>('/settings/mode-switch-preview').then(r => r.data),
 
@@ -868,59 +890,65 @@ export const settingsApi = {
   deleteUnit: (id: number) => api.delete(`/settings/units/${id}`).then(r => r.data),
 
   // Email branding (M16)
-  listEmailProfiles: () =>
-    api.get<EmailProfile[]>('/settings/email-profiles').then(r => r.data),
-  createEmailProfile: (payload: EmailProfilePayload) =>
-    api.post<EmailProfile>('/settings/email-profiles', payload).then(r => r.data),
-  updateEmailProfile: (id: number, payload: Partial<EmailProfilePayload>) =>
-    api.put<EmailProfile>(`/settings/email-profiles/${id}`, payload).then(r => r.data),
-  testEmailProfile: (id: number) =>
-    api.post<EmailProfileTestResult>(`/settings/email-profiles/${id}/test`, {}).then(r => r.data),
-  testEmailProfileDraft: (payload: EmailProfilePayload, id?: number | null) =>
-    api.post<EmailProfileTestResult>('/settings/email-profiles/test', id ? { ...payload, id } : payload).then(r => r.data),
-  testEmailProfileImapSettings: (payload: Partial<EmailProfilePayload>, id?: number | null) =>
+  listEmailProfiles: (clientScoped = false) =>
+    api.get<EmailProfile[]>(clientScoped ? '/settings/client/email-profiles' : '/settings/email-profiles').then(r => r.data),
+  createEmailProfile: (payload: EmailProfilePayload, clientScoped = false) =>
+    api.post<EmailProfile>(clientScoped ? '/settings/client/email-profiles' : '/settings/email-profiles', payload).then(r => r.data),
+  updateEmailProfile: (id: number, payload: Partial<EmailProfilePayload>, clientScoped = false) =>
+    api.put<EmailProfile>(clientScoped ? `/settings/client/email-profiles/${id}` : `/settings/email-profiles/${id}`, payload).then(r => r.data),
+  testEmailProfile: (id: number, clientScoped = false) =>
+    api.post<EmailProfileTestResult>(clientScoped ? `/settings/client/email-profiles/${id}/test` : `/settings/email-profiles/${id}/test`, {}).then(r => r.data),
+  testEmailProfileDraft: (payload: EmailProfilePayload, id?: number | null, clientScoped = false) =>
+    api.post<EmailProfileTestResult>(clientScoped ? '/settings/client/email-profiles/test' : '/settings/email-profiles/test', id ? { ...payload, id } : payload).then(r => r.data),
+  testEmailProfileImapSettings: (payload: Partial<EmailProfilePayload>, id?: number | null, clientScoped = false) =>
     api.post<EmailProfileImapFoldersResult>(
-      id ? `/settings/email-profiles/${id}/imap-test` : '/settings/email-profiles/imap-test',
+      id
+        ? (clientScoped ? `/settings/client/email-profiles/${id}/imap-test` : `/settings/email-profiles/${id}/imap-test`)
+        : (clientScoped ? '/settings/client/email-profiles/imap-test' : '/settings/email-profiles/imap-test'),
       payload,
     ).then(r => r.data),
-  browseEmailProfileImapFolders: (payload: Partial<EmailProfilePayload>, id?: number | null) =>
+  browseEmailProfileImapFolders: (payload: Partial<EmailProfilePayload>, id?: number | null, clientScoped = false) =>
     api.post<EmailProfileImapFoldersResult>(
-      id ? `/settings/email-profiles/${id}/folders` : '/settings/email-profiles/folders',
+      id
+        ? (clientScoped ? `/settings/client/email-profiles/${id}/folders` : `/settings/email-profiles/${id}/folders`)
+        : (clientScoped ? '/settings/client/email-profiles/folders' : '/settings/email-profiles/folders'),
       payload,
     ).then(r => r.data),
-  deleteEmailProfile: (id: number) =>
-    api.delete<{ deleted: boolean }>(`/settings/email-profiles/${id}`).then(r => r.data),
+  deleteEmailProfile: (id: number, clientScoped = false) =>
+    api.delete<{ deleted: boolean }>(clientScoped ? `/settings/client/email-profiles/${id}` : `/settings/email-profiles/${id}`).then(r => r.data),
 
-  uploadEmailLogo: (file: File) => {
+  uploadEmailLogo: (file: File, clientScoped = false) => {
     const fd = new FormData()
     fd.append('file', file)
     return api.post<{ logo_path: string; width: number; height: number }>(
-      '/settings/email-branding/logo',
+      clientScoped ? '/settings/client/branding/logo' : '/settings/email-branding/logo',
       fd,
       { headers: { 'Content-Type': 'multipart/form-data' } },
     ).then(r => r.data)
   },
-  deleteEmailLogo: () => api.delete('/settings/email-branding/logo').then(r => r.data),
+  deleteEmailLogo: (clientScoped = false) =>
+    api.delete(clientScoped ? '/settings/client/branding/logo' : '/settings/email-branding/logo').then(r => r.data),
 
-  listBrandingProfiles: () =>
-    api.get<BrandingProfile[]>('/settings/branding-profiles').then(r => r.data),
-  createBrandingProfile: (payload: Partial<BrandingProfile>) =>
-    api.post<BrandingProfile>('/settings/branding-profiles', payload).then(r => r.data),
-  updateBrandingProfile: (id: number, payload: Partial<BrandingProfile>) =>
-    api.put<BrandingProfile>(`/settings/branding-profiles/${id}`, payload).then(r => r.data),
-  deleteBrandingProfile: (id: number) =>
-    api.delete<{ deleted: boolean }>(`/settings/branding-profiles/${id}`).then(r => r.data),
-  setDefaultBrandingProfile: (id: number) =>
-    api.post<BrandingProfile>(`/settings/branding-profiles/${id}/default`, {}).then(r => r.data),
-  uploadBrandingProfileLogo: (id: number, file: File) => {
+  listBrandingProfiles: (clientScoped = false) =>
+    api.get<BrandingProfile[]>(clientScoped ? '/settings/client/branding/profiles' : '/settings/branding-profiles').then(r => r.data),
+  createBrandingProfile: (payload: Partial<BrandingProfile>, clientScoped = false) =>
+    api.post<BrandingProfile>(clientScoped ? '/settings/client/branding/profiles' : '/settings/branding-profiles', payload).then(r => r.data),
+  updateBrandingProfile: (id: number, payload: Partial<BrandingProfile>, clientScoped = false) =>
+    api.put<BrandingProfile>(clientScoped ? `/settings/client/branding/profiles/${id}` : `/settings/branding-profiles/${id}`, payload).then(r => r.data),
+  deleteBrandingProfile: (id: number, clientScoped = false) =>
+    api.delete<{ deleted: boolean }>(clientScoped ? `/settings/client/branding/profiles/${id}` : `/settings/branding-profiles/${id}`).then(r => r.data),
+  setDefaultBrandingProfile: (id: number, clientScoped = false) =>
+    api.post<BrandingProfile>(clientScoped ? `/settings/client/branding/profiles/${id}/default` : `/settings/branding-profiles/${id}/default`, {}).then(r => r.data),
+  uploadBrandingProfileLogo: (id: number, file: File, clientScoped = false) => {
     const fd = new FormData()
     fd.append('file', file)
-    return api.post<BrandingProfile>(`/settings/branding-profiles/${id}/logo`, fd, {
+    const path = clientScoped ? `/settings/client/branding/profiles/${id}/logo` : `/settings/branding-profiles/${id}/logo`
+    return api.post<BrandingProfile>(path, fd, {
       headers: { 'Content-Type': 'multipart/form-data' },
     }).then(r => r.data)
   },
-  deleteBrandingProfileLogo: (id: number) =>
-    api.delete<BrandingProfile>(`/settings/branding-profiles/${id}/logo`).then(r => r.data),
+  deleteBrandingProfileLogo: (id: number, clientScoped = false) =>
+    api.delete<BrandingProfile>(clientScoped ? `/settings/client/branding/profiles/${id}/logo` : `/settings/branding-profiles/${id}/logo`).then(r => r.data),
 
   getPdfSigningDiagnostics: () =>
     api.get<PdfSigningDiagnostics>('/settings/pdf-signing/diagnostics').then(r => r.data),
@@ -1027,8 +1055,8 @@ export const settingsApi = {
     api.get<{ items: NaceCode[] }>('/settings/nace-codes', { params: { q, limit } }).then(r => r.data.items),
 
   // Vrací HTML string — frontend ho pak nacpe do iframe.srcdoc (obejde X-Frame-Options DENY).
-  emailPreviewHtml: (locale: 'cs' | 'en' = 'cs', brandingProfileId: number | null = null) =>
-    api.get<string>('/settings/email-branding/preview', {
+  emailPreviewHtml: (locale: 'cs' | 'en' = 'cs', brandingProfileId: number | null = null, clientScoped = false) =>
+    api.get<string>(clientScoped ? '/settings/client/branding/preview' : '/settings/email-branding/preview', {
       params: { locale, ...(brandingProfileId !== null ? { branding_profile_id: brandingProfileId } : {}) },
       responseType: 'text',
       transformResponse: [(d) => d],

--- a/web/src/components/layout/AppLayout.vue
+++ b/web/src/components/layout/AppLayout.vue
@@ -26,7 +26,7 @@ import WorkspaceHost from '@/components/workspace/WorkspaceHost.vue'
 import WorkspaceLayoutToggle from '@/components/workspace/WorkspaceLayoutToggle.vue'
 import WorkspaceNavLink from '@/components/workspace/WorkspaceNavLink.vue'
 import PaneActivityScope from '@/components/workspace/PaneActivityScope.vue'
-import type { PermissionKey } from '@/security/permissions'
+import type { AccessLevel, PermissionKey } from '@/security/permissions'
 import { useSessionSecurityStore } from '@/stores/sessionSecurity'
 import { useToast } from '@/composables/useToast'
 import { formatShortcut, useKeyboardShortcuts, type ShortcutAction } from '@/composables/useKeyboardShortcuts'
@@ -124,6 +124,7 @@ interface NavItem {
   /** Cílová route pro rychlé „+" (vytvořit nový) vpravo u položky. Jen pro zapisující. */
   newTo?: string
   permission?: PermissionKey
+  access?: AccessLevel
   newPermission?: PermissionKey
   badge?: number
   dividerBefore?: boolean
@@ -277,8 +278,8 @@ const ICONS = {
 }
 
 const navSections = computed<NavSection[]>(() => {
-  // Role client (Epic F6): samostatný, minimální nav — Přehled (portál), Fakturace,
-  // Nákupy, Kontakty, Nápověda. Vše ostatní skryto (BE stejně deny-by-default).
+  // Role client (Epic F6): samostatný, minimální nav. Sekce Firma se přidá jen
+  // při `settings.company = WRITE`; vše ostatní drží BE deny-by-default.
   if (clientExperience.value) {
     return filterNavigation([
       { key: 'dashboard', title: t('nav.dashboard'), accent: 'teal', items: [{ to: '/portal', label: t('nav.portal'), icon: ICONS.dashboard }] },
@@ -316,6 +317,18 @@ const navSections = computed<NavSection[]>(() => {
           { to: '/portal/purchase-invoice-submissions', label: t('nav.submit_documents'), icon: ICONS.documents, permission: 'documents.submit' as PermissionKey },
           { to: '/portal/document-requests', label: t('nav.document_requests'), icon: ICONS.requestDoc, permission: 'documents.submit' as PermissionKey },
         ],
+      },
+      {
+        key: 'company',
+        title: t('nav.section_company'),
+        accent: 'primaryDeep',
+        items: [{
+          to: '/portal/settings',
+          label: t('nav.company_settings'),
+          icon: ICONS.settings,
+          permission: 'settings.company' as PermissionKey,
+          access: 'write',
+        }],
       },
     ])
   }
@@ -791,7 +804,7 @@ function filterNavigation(sections: NavSection[]): NavSection[] {
       if (item.to.startsWith('/admin/branding')) return auth.isDemo ? auth.canRead('settings.branding') : auth.canWrite('settings.branding')
       if (item.to.startsWith('/admin/electronic-signatures')) return auth.canWrite('settings.signing')
       if (item.to.startsWith('/admin/databox')) return auth.canWrite('settings.signing')
-      return permission ? auth.canRead(permission) : auth.isSuperadmin
+      return permission ? auth.can(permission, item.access ?? 'read') : auth.isSuperadmin
     }),
   })).filter(section => section.items.length > 0)
 }

--- a/web/src/components/settings/BrandingProfilesSettings.vue
+++ b/web/src/components/settings/BrandingProfilesSettings.vue
@@ -1,13 +1,19 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { settingsApi, type BrandingProfile, type EmailProfile, type Supplier } from '@/api/settings'
+import { settingsApi, type BrandingProfile, type EmailProfile, type OperationalBrandingSettings } from '@/api/settings'
 import { useToast } from '@/composables/useToast'
 import EmptyState from '@/components/ui/EmptyState.vue'
 
 const { t } = useI18n()
 const toast = useToast()
-const props = defineProps<{ enabled: boolean; supplier: Supplier | null }>()
+const props = withDefaults(defineProps<{
+  enabled: boolean
+  supplier: OperationalBrandingSettings | null
+  clientScoped?: boolean
+}>(), {
+  clientScoped: false,
+})
 const emit = defineEmits<{
   (event: 'changed'): void
   (event: 'update:enabled', value: boolean): void
@@ -37,15 +43,16 @@ const emptyProfile = (): Partial<BrandingProfile> => ({
 
 async function load() {
   const [loadedProfiles, loadedEmailProfiles] = await Promise.all([
-    settingsApi.listBrandingProfiles(), settingsApi.listEmailProfiles().catch(() => [] as EmailProfile[]),
+    settingsApi.listBrandingProfiles(props.clientScoped),
+    settingsApi.listEmailProfiles(props.clientScoped).catch(() => [] as EmailProfile[]),
   ])
   profiles.value = loadedProfiles
-  emailProfiles.value = loadedEmailProfiles.filter(profile => profile.is_active)
+  emailProfiles.value = loadedEmailProfiles.filter(profile => profile.is_active && profile.client_manageable !== false)
 }
 
 async function openEmailPreview(profile: BrandingProfile, locale: 'cs' | 'en' = 'cs') {
   try {
-    const html = await settingsApi.emailPreviewHtml(locale, profile.id)
+    const html = await settingsApi.emailPreviewHtml(locale, profile.id, props.clientScoped)
     emailPreview.value = { profile, locale, html }
   } catch (e: any) { toast.error(e?.response?.data?.error?.message || t('common.error')) }
 }
@@ -57,7 +64,7 @@ async function changeEmailPreviewLocale(locale: 'cs' | 'en') {
 
 async function setDefault(profile: BrandingProfile) {
   try {
-    await settingsApi.setDefaultBrandingProfile(profile.id)
+    await settingsApi.setDefaultBrandingProfile(profile.id, props.clientScoped)
     await load(); emit('changed'); toast.success(t('settings.branding_profiles.default_changed'))
   } catch (e: any) { toast.error(e?.response?.data?.error?.message || t('common.error')) }
 }
@@ -74,8 +81,8 @@ async function save() {
   }
   saving.value = true
   try {
-    if (editing.value.id) await settingsApi.updateBrandingProfile(editing.value.id, editing.value)
-    else await settingsApi.createBrandingProfile(editing.value)
+    if (editing.value.id) await settingsApi.updateBrandingProfile(editing.value.id, editing.value, props.clientScoped)
+    else await settingsApi.createBrandingProfile(editing.value, props.clientScoped)
     editing.value = null
     await load()
     emit('changed')
@@ -88,7 +95,7 @@ async function save() {
 async function remove(profile: BrandingProfile) {
   if (!confirm(t('settings.branding_profiles.delete_confirm', { name: profile.name }))) return
   try {
-    await settingsApi.deleteBrandingProfile(profile.id)
+    await settingsApi.deleteBrandingProfile(profile.id, props.clientScoped)
     await load()
     emit('changed')
   } catch (e: any) { toast.error(e?.response?.data?.error?.message || t('common.error')) }
@@ -104,7 +111,7 @@ async function uploadLogo(profile: BrandingProfile, event: Event) {
     return
   }
   try {
-    await settingsApi.uploadBrandingProfileLogo(profile.id, file)
+    await settingsApi.uploadBrandingProfileLogo(profile.id, file, props.clientScoped)
     await load()
     emit('changed')
   } catch (e: any) {
@@ -115,7 +122,7 @@ async function uploadLogo(profile: BrandingProfile, event: Event) {
 async function deleteLogo(profile: BrandingProfile) {
   if (!confirm(t('settings.branding_logo_remove_confirm'))) return
   try {
-    await settingsApi.deleteBrandingProfileLogo(profile.id)
+    await settingsApi.deleteBrandingProfileLogo(profile.id, props.clientScoped)
     await load()
     emit('changed')
   } catch (e: any) { toast.error(e?.response?.data?.error?.message || t('common.error')) }
@@ -135,7 +142,8 @@ async function toggleModule(event: Event) {
   }
   togglingModule.value = true
   try {
-    await settingsApi.updateSupplier({ branding_profiles_enabled: next })
+    if (props.clientScoped) await settingsApi.updateClientBranding({ branding_profiles_enabled: next })
+    else await settingsApi.updateSupplier({ branding_profiles_enabled: next })
     emit('update:enabled', next)
     if (next) await load()
     emit('changed')

--- a/web/src/i18n/cs.json
+++ b/web/src/i18n/cs.json
@@ -456,6 +456,7 @@
     "payroll_erasure": "Výmaz osobních údajů",
     "payroll_benefit_baskets": "Koše benefitů",
     "settings": "Nastavení",
+    "company_settings": "Nastavení firmy",
     "branding": "Branding",
     "supplier_current": "Dodavatel",
     "suppliers": "Dodavatelé",
@@ -12681,6 +12682,11 @@
     "field_balance": "Disponibilní zůstatek"
   },
   "settings": {
+    "client_company_settings_title": "Nastavení firmy",
+    "client_company_settings_hint": "Správa odesílacích profilů a vzhledu komunikace aktuální firmy. Účetní, daňové, právní a systémové nastavení zůstává ve správě účetní.",
+    "client_company_settings_tabs": "Sekce nastavení firmy",
+    "email_profile_managed_by_staff": "Spravuje účetní",
+    "email_profile_managed_by_staff_hint": "Profil používá systémový sendmail nebo kryptografický podpis a může jej změnit pouze správce instalace.",
     "branding_profiles": {
       "title": "Brandingové profily",
       "hint": "Volitelné identity pro různá loga, názvy a kontaktní údaje. Právní údaje dodavatele zůstávají stejné.",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -456,6 +456,7 @@
     "payroll_erasure": "Erasure of personal data",
     "payroll_benefit_baskets": "Benefit baskets",
     "settings": "Settings",
+    "company_settings": "Company settings",
     "branding": "Branding",
     "supplier_current": "Supplier",
     "suppliers": "Suppliers",
@@ -12681,6 +12682,11 @@
     "field_balance": "Available balance"
   },
   "settings": {
+    "client_company_settings_title": "Company settings",
+    "client_company_settings_hint": "Manage sending profiles and communication branding for the current company. Accounting, tax, legal and system settings remain with your accountant.",
+    "client_company_settings_tabs": "Company settings sections",
+    "email_profile_managed_by_staff": "Managed by accountant",
+    "email_profile_managed_by_staff_hint": "This profile uses system sendmail or a cryptographic signature and can only be changed by the installation administrator.",
     "branding_profiles": {
       "title": "Branding profiles",
       "hint": "Optional identities for different logos, names and contact details. The supplier's legal details remain unchanged.",

--- a/web/src/i18n/namespaces.generated.json
+++ b/web/src/i18n/namespaces.generated.json
@@ -226,6 +226,9 @@
       "purchase_invoice",
       "purchase_submissions"
     ],
+    "portal-company-settings": [
+      "settings"
+    ],
     "clients": [
       "purchase_invoice"
     ],

--- a/web/src/pages/admin/Branding.vue
+++ b/web/src/pages/admin/Branding.vue
@@ -1,16 +1,19 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { settingsApi, type Supplier } from '@/api/settings'
+import { settingsApi, type OperationalBrandingSettings } from '@/api/settings'
 import { useToast } from '@/composables/useToast'
 import { useDemoMode } from '@/composables/useDemoMode'
 import { ICONS, btnOutline } from '@/components/ui/buttonStyles'
 import BrandingProfilesSettings from '@/components/settings/BrandingProfilesSettings.vue'
 
 const { t } = useI18n()
+const props = withDefaults(defineProps<{ clientScoped?: boolean }>(), {
+  clientScoped: false,
+})
 const toast = useToast()
 const { blockDemoMutation } = useDemoMode()
-const supplier = ref<Supplier | null>(null)
+const supplier = ref<OperationalBrandingSettings | null>(null)
 const loading = ref(true)
 const previewLocale = ref<'cs' | 'en'>('cs')
 const previewHtml = ref('')
@@ -22,7 +25,7 @@ let colorTimer: ReturnType<typeof setTimeout> | null = null
 async function bumpPreview() {
   if (!supplier.value) return
   try {
-    previewHtml.value = await settingsApi.emailPreviewHtml(previewLocale.value)
+    previewHtml.value = await settingsApi.emailPreviewHtml(previewLocale.value, null, props.clientScoped)
   } catch (e: any) {
     previewHtml.value = `<pre style="color:red">${e?.message || 'Preview failed'}</pre>`
   }
@@ -31,7 +34,9 @@ async function bumpPreview() {
 async function load() {
   loading.value = true
   try {
-    supplier.value = await settingsApi.getSupplier()
+    supplier.value = props.clientScoped
+      ? await settingsApi.getClientBranding()
+      : await settingsApi.getSupplier()
     await bumpPreview()
     setTimeout(() => { watching = true }, 0)
   } finally {
@@ -47,11 +52,14 @@ async function saveBranding(silent = false) {
     return
   }
   try {
-    const updated = await settingsApi.updateSupplier({
+    const payload = {
       email_branding_enabled: supplier.value.email_branding_enabled,
       email_accent_color: supplier.value.email_accent_color,
       pdf_logo_show_name: supplier.value.pdf_logo_show_name,
-    })
+    }
+    const updated = props.clientScoped
+      ? await settingsApi.updateClientBranding(payload)
+      : await settingsApi.updateSupplier(payload)
     supplier.value = { ...supplier.value, ...updated }
     if (!silent) toast.success(t('common.saved'))
     await bumpPreview()
@@ -75,7 +83,7 @@ async function onLogoSelected(ev: Event) {
   }
   logoUploading.value = true
   try {
-    const result = await settingsApi.uploadEmailLogo(file)
+    const result = await settingsApi.uploadEmailLogo(file, props.clientScoped)
     supplier.value.logo_path = result.logo_path
     supplier.value.has_email_logo = true
     toast.success(t('settings.branding_logo_uploaded'))
@@ -92,7 +100,7 @@ async function removeLogo() {
   if (blockDemoMutation()) return
   if (!supplier.value || !window.confirm(t('settings.branding_logo_remove_confirm'))) return
   try {
-    await settingsApi.deleteEmailLogo()
+    await settingsApi.deleteEmailLogo(props.clientScoped)
     supplier.value.logo_path = null
     supplier.value.has_email_logo = false
     toast.success(t('settings.branding_logo_removed'))
@@ -124,7 +132,12 @@ onMounted(load)
     <div v-if="loading" class="text-center text-neutral-500 py-12 text-sm">{{ t('common.loading') }}</div>
 
     <template v-else-if="supplier">
-    <BrandingProfilesSettings v-model:enabled="supplier.branding_profiles_enabled" :supplier="supplier" @changed="load" />
+    <BrandingProfilesSettings
+      v-model:enabled="supplier.branding_profiles_enabled"
+      :supplier="supplier"
+      :client-scoped="props.clientScoped"
+      @changed="load"
+    />
 
     <section class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm mt-5">
       <div class="flex flex-wrap items-center justify-between gap-3 mb-5">

--- a/web/src/pages/admin/EmailProfiles.vue
+++ b/web/src/pages/admin/EmailProfiles.vue
@@ -15,6 +15,9 @@ import EmptyState from '@/components/ui/EmptyState.vue'
 
 const { t } = useI18n()
 const auth = useAuthStore()
+const props = withDefaults(defineProps<{ clientScoped?: boolean }>(), {
+  clientScoped: false,
+})
 
 /**
  * H-02 — spravovaná instalace: odesílá hosting, obálku určuje jeho MTA a na ní
@@ -226,8 +229,8 @@ async function load() {
   loading.value = true
   try {
     const [profileRows, signingRows] = await Promise.all([
-      settingsApi.listEmailProfiles(),
-      settingsApi.listSigningProfiles(),
+      settingsApi.listEmailProfiles(props.clientScoped),
+      props.clientScoped ? Promise.resolve([] as SigningProfile[]) : settingsApi.listSigningProfiles(),
     ])
     profiles.value = profileRows
     signingProfiles.value = signingRows
@@ -310,7 +313,7 @@ function editProfile(profile: EmailProfile) {
   draft.reply_to_email = profile.reply_to_email || ''
   draft.reply_to_name = profile.reply_to_name || ''
   draft.reply_to_enabled = profile.reply_to_enabled
-  draft.signing_profile_id = profile.signing_profile_id
+  draft.signing_profile_id = profile.signing_profile_id ?? null
   draft.dkim_domain = profile.dkim_domain || ''
   draft.dkim_selector = profile.dkim_selector || ''
   draft.dkim_enabled = profile.dkim_enabled
@@ -349,7 +352,7 @@ function editProfile(profile: EmailProfile) {
 }
 
 function payload(): EmailProfilePayload {
-  return {
+  const data: EmailProfilePayload = {
     name: draft.name,
     code: draft.code,
     from_email: draft.from_email,
@@ -390,6 +393,11 @@ function payload(): EmailProfilePayload {
     is_default: draft.is_default,
     is_active: draft.is_active,
   }
+  if (props.clientScoped) {
+    delete data.signing_profile_id
+    delete data.sendmail_command
+  }
+  return data
 }
 
 function imapBrowsePayload(): Partial<EmailProfilePayload> {
@@ -430,9 +438,9 @@ async function saveProfile() {
   try {
     const data = payload()
     if (editingId.value === null) {
-      await settingsApi.createEmailProfile(data)
+      await settingsApi.createEmailProfile(data, props.clientScoped)
     } else {
-      await settingsApi.updateEmailProfile(editingId.value, data)
+      await settingsApi.updateEmailProfile(editingId.value, data, props.clientScoped)
     }
     showForm.value = false
     resetDraft()
@@ -451,7 +459,7 @@ async function deleteProfile(profile: EmailProfile) {
   if (!window.confirm(t('settings.email_profile_delete_confirm', { name: profile.name }))) return
   deletingId.value = profile.id
   try {
-    await settingsApi.deleteEmailProfile(profile.id)
+    await settingsApi.deleteEmailProfile(profile.id, props.clientScoped)
     profiles.value = profiles.value.filter(row => row.id !== profile.id)
     toast.success(t('settings.email_profile_deleted'))
   } catch (e: any) {
@@ -464,7 +472,7 @@ async function deleteProfile(profile: EmailProfile) {
 async function testProfile(profile: EmailProfile) {
   testingId.value = profile.id
   try {
-    const result = await settingsApi.testEmailProfile(profile.id)
+    const result = await settingsApi.testEmailProfile(profile.id, props.clientScoped)
     toast.success(t('settings.email_profile_test_sent', { email: result.sent_to.join(', ') }))
     if (result.imap_append?.status === 'failed') {
       toast.error(imapAppendText(result.imap_append))
@@ -487,7 +495,7 @@ async function testDraftProfile() {
   testingDraft.value = true
   draftTestFeedback.value = null
   try {
-    const result = await settingsApi.testEmailProfileDraft(payload(), editingId.value)
+    const result = await settingsApi.testEmailProfileDraft(payload(), editingId.value, props.clientScoped)
     const recipients = result.sent_to.join(', ')
     draftTestFeedback.value = {
       status: 'success',
@@ -519,7 +527,7 @@ async function browseImapFolders() {
   browsingImapFolders.value = true
   imapFolderOptions.value = []
   try {
-    const result = await settingsApi.browseEmailProfileImapFolders(imapBrowsePayload(), editingId.value)
+    const result = await settingsApi.browseEmailProfileImapFolders(imapBrowsePayload(), editingId.value, props.clientScoped)
     imapFolderOptions.value = result.folders ?? []
     if (imapFolderOptions.value.length > 0) {
       toast.success(t('settings.email_profile_imap_folders_loaded', { count: imapFolderOptions.value.length }))
@@ -545,7 +553,7 @@ async function testImapSettings() {
 
   testingImapSettings.value = true
   try {
-    await settingsApi.testEmailProfileImapSettings(imapBrowsePayload(), editingId.value)
+    await settingsApi.testEmailProfileImapSettings(imapBrowsePayload(), editingId.value, props.clientScoped)
     toast.success(t('settings.email_profile_imap_test_ok', { folder: draft.imap_folder || 'Sent' }))
   } catch (e: any) {
     toast.error(
@@ -734,7 +742,7 @@ function certificateCommonName(subject: string | null | undefined): string | nul
           {{ t('settings.email_profile_from_name') }}
           <input v-model="draft.from_name" class="mt-1 w-full rounded-md border border-neutral-300 bg-surface px-3 py-2 text-sm" />
         </label>
-        <label class="block text-xs font-medium text-neutral-600">
+        <label v-if="!props.clientScoped" class="block text-xs font-medium text-neutral-600">
           {{ t('settings.email_profile_signing_profile') }}
           <select v-model="draft.signing_profile_id" class="mt-1 w-full rounded-md border border-neutral-300 bg-surface px-3 py-2 text-sm">
             <option :value="null">{{ t('settings.email_profile_signing_none') }}</option>
@@ -811,7 +819,7 @@ function certificateCommonName(subject: string | null | undefined): string | nul
               -->
               <option value="global">{{ t('settings.email_profile_transport_global') }}</option>
               <option value="smtp">{{ t('settings.email_profile_transport_smtp') }}</option>
-              <option value="sendmail">{{ t('settings.email_profile_transport_sendmail') }}</option>
+              <option v-if="!props.clientScoped" value="sendmail">{{ t('settings.email_profile_transport_sendmail') }}</option>
             </select>
           </label>
           <p v-if="transportLocked" class="mt-1.5 flex gap-1.5 text-xs text-neutral-500">
@@ -1051,7 +1059,7 @@ function certificateCommonName(subject: string | null | undefined): string | nul
               <th class="px-3 py-2 text-left font-medium">{{ t('settings.email_profile_name') }}</th>
               <th class="px-3 py-2 text-left font-medium">{{ t('settings.email_profile_from') }}</th>
               <th class="px-3 py-2 text-left font-medium">{{ t('settings.email_profile_reply_to') }}</th>
-              <th class="px-3 py-2 text-left font-medium">{{ t('settings.email_profile_signing_profile') }}</th>
+              <th v-if="!props.clientScoped" class="px-3 py-2 text-left font-medium">{{ t('settings.email_profile_signing_profile') }}</th>
               <th class="px-3 py-2 text-left font-medium">{{ t('settings.email_profile_dkim') }}</th>
               <th class="px-3 py-2 text-left font-medium">{{ t('settings.email_profile_transport') }}</th>
               <th class="px-3 py-2 text-left font-medium">{{ t('settings.email_profile_imap_sent') }}</th>
@@ -1076,7 +1084,7 @@ function certificateCommonName(subject: string | null | undefined): string | nul
                 </template>
                 <span v-else class="text-neutral-400">{{ t('settings.email_profile_reply_to_disabled') }}</span>
               </td>
-              <td class="px-3 py-2">{{ signingProfileLabel(profile) }}</td>
+              <td v-if="!props.clientScoped" class="px-3 py-2">{{ signingProfileLabel(profile) }}</td>
               <td class="px-3 py-2">
                 <template v-if="profile.dkim_enabled">
                   <div>{{ profile.dkim_domain }}</div>
@@ -1109,17 +1117,22 @@ function certificateCommonName(subject: string | null | undefined): string | nul
                 </div>
               </td>
               <td class="px-3 py-2 text-right whitespace-nowrap">
-                <button type="button" @click="testProfile(profile)" :disabled="testingId === profile.id"
-                  class="cursor-pointer text-neutral-600 hover:text-neutral-800 disabled:opacity-50">
-                  {{ testingId === profile.id ? t('common.loading') : t('settings.email_profile_test') }}
-                </button>
-                <button type="button" @click="editProfile(profile)" class="cursor-pointer ml-3 text-primary-600 hover:text-primary-700">
-                  {{ t('common.edit') }}
-                </button>
-                <button type="button" @click="deleteProfile(profile)" :disabled="deletingId === profile.id"
-                  class="cursor-pointer ml-3 text-danger-600 hover:text-danger-700 disabled:opacity-50">
-                  {{ deletingId === profile.id ? t('common.loading') : t('common.delete') }}
-                </button>
+                <template v-if="profile.client_manageable !== false">
+                  <button type="button" @click="testProfile(profile)" :disabled="testingId === profile.id"
+                    class="cursor-pointer text-neutral-600 hover:text-neutral-800 disabled:opacity-50">
+                    {{ testingId === profile.id ? t('common.loading') : t('settings.email_profile_test') }}
+                  </button>
+                  <button type="button" @click="editProfile(profile)" class="cursor-pointer ml-3 text-primary-600 hover:text-primary-700">
+                    {{ t('common.edit') }}
+                  </button>
+                  <button type="button" @click="deleteProfile(profile)" :disabled="deletingId === profile.id"
+                    class="cursor-pointer ml-3 text-danger-600 hover:text-danger-700 disabled:opacity-50">
+                    {{ deletingId === profile.id ? t('common.loading') : t('common.delete') }}
+                  </button>
+                </template>
+                <span v-else class="text-neutral-500" :title="t('settings.email_profile_managed_by_staff_hint')">
+                  {{ t('settings.email_profile_managed_by_staff') }}
+                </span>
               </td>
             </tr>
           </tbody>

--- a/web/src/pages/portal/ClientCompanySettings.vue
+++ b/web/src/pages/portal/ClientCompanySettings.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
+import EmailProfiles from '@/pages/admin/EmailProfiles.vue'
+import Branding from '@/pages/admin/Branding.vue'
+
+type SettingsTab = 'email-profiles' | 'branding'
+
+const { t } = useI18n()
+const route = useRoute()
+const router = useRouter()
+const tabs: SettingsTab[] = ['email-profiles', 'branding']
+
+function tabFromQuery(value: unknown): SettingsTab {
+  const candidate = String(value ?? '') as SettingsTab
+  return tabs.includes(candidate) ? candidate : 'email-profiles'
+}
+
+const activeTab = ref<SettingsTab>(tabFromQuery(route.query.tab))
+
+watch(() => route.query.tab, value => {
+  activeTab.value = tabFromQuery(value)
+})
+
+function switchTab(tab: SettingsTab) {
+  if (activeTab.value === tab) return
+  activeTab.value = tab
+  void router.replace({ query: { ...route.query, tab } })
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <header>
+      <h1 class="text-2xl font-semibold">{{ t('settings.client_company_settings_title') }}</h1>
+      <p class="mt-1 max-w-3xl text-sm text-neutral-500">
+        {{ t('settings.client_company_settings_hint') }}
+      </p>
+    </header>
+
+    <nav class="flex flex-wrap border-b border-neutral-200" :aria-label="t('settings.client_company_settings_tabs')">
+      <button
+        type="button"
+        class="-mb-px cursor-pointer whitespace-nowrap border-b-2 px-4 py-2 text-sm font-medium transition-colors"
+        :class="activeTab === 'email-profiles' ? 'border-primary-600 text-primary-700' : 'border-transparent text-neutral-500 hover:text-neutral-700'"
+        @click="switchTab('email-profiles')"
+      >
+        {{ t('nav.email_profiles') }}
+      </button>
+      <button
+        type="button"
+        class="-mb-px cursor-pointer whitespace-nowrap border-b-2 px-4 py-2 text-sm font-medium transition-colors"
+        :class="activeTab === 'branding' ? 'border-primary-600 text-primary-700' : 'border-transparent text-neutral-500 hover:text-neutral-700'"
+        @click="switchTab('branding')"
+      >
+        {{ t('nav.branding') }}
+      </button>
+    </nav>
+
+    <EmailProfiles v-if="activeTab === 'email-profiles'" client-scoped />
+    <Branding v-else client-scoped />
+  </div>
+</template>

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -70,7 +70,7 @@ const routes: RouteRecordRaw[] = [
 
 const routePermissions: Record<string, [PermissionKey, AccessLevel?]> = {
   home: ['dashboard'], portal: ['profile'], 'portal-document-requests': ['documents.submit'],
-  'portal-purchase-invoice-submissions': ['documents.submit'],
+  'portal-purchase-invoice-submissions': ['documents.submit'], 'portal-company-settings': ['settings.company', 'write'],
   clients: ['clients'], 'client-new': ['clients.create', 'write'], 'client-detail': ['clients'], 'client-edit': ['clients', 'write'],
   projects: ['projects'], 'project-new': ['projects.create', 'write'], 'project-detail': ['projects'], 'project-edit': ['projects', 'write'],
   invoices: ['invoices'], 'invoice-new': ['invoices.create', 'write'], 'invoice-detail': ['invoices'], 'invoice-edit': ['invoices', 'write'],

--- a/web/src/router/workspaceRoutes.ts
+++ b/web/src/router/workspaceRoutes.ts
@@ -9,6 +9,7 @@ export function createWorkspaceRoutes(): RouteRecordRaw[] {
       // Vyžádání chybějících dokladů (Fáze F, audit 2026-07) — klientský portál.
       { path: 'portal/document-requests', name: 'portal-document-requests', component: () => import('@/pages/portal/DocumentRequests.vue'), meta: {  } },
       { path: 'portal/purchase-invoice-submissions', name: 'portal-purchase-invoice-submissions', component: () => import('@/pages/portal/PurchaseInvoiceSubmissions.vue'), meta: { requiresSupplier: true } },
+      { path: 'portal/settings', name: 'portal-company-settings', component: () => import('@/pages/portal/ClientCompanySettings.vue'), meta: { requiresSupplier: true } },
       { path: 'clients',                name: 'clients',        component: () => import('@/pages/clients/ClientList.vue'), meta: {  } },
       { path: 'clients/new',            name: 'client-new',     component: () => import('@/pages/clients/ClientForm.vue'), meta: { requiresSupplier: true } },
       { path: 'clients/:id(\\d+)',      name: 'client-detail',  component: () => import('@/pages/clients/ClientDetail.vue'), meta: {  } },

--- a/web/src/security/__tests__/clientRoutePolicy.spec.ts
+++ b/web/src/security/__tests__/clientRoutePolicy.spec.ts
@@ -285,9 +285,9 @@ function clientRouteParityErrors(manifestRoutes: readonly ManifestRoute[]): stri
 }
 
 describe('sdílená klientská plocha vlastní domény', () => {
-  it('obsahuje auditovaných 33 core rout a tři legacy aliasy', () => {
-    expect(clientDomainRoutes).toHaveLength(36)
-    expect(new Set(clientDomainRoutes.map(route => route.name)).size).toBe(36)
+  it('obsahuje auditovanou klientskou plochu včetně nastavení firmy a legacy aliasů', () => {
+    expect(clientDomainRoutes).toHaveLength(37)
+    expect(new Set(clientDomainRoutes.map(route => route.name)).size).toBe(37)
     expect(clientDomainRoutes.slice(-3).map(route => route.name))
       .toEqual(['data-exchange', 'admin-export', 'admin-import'])
   })
@@ -309,7 +309,7 @@ describe('sdílená klientská plocha vlastní domény', () => {
       if (route!.path.includes(':')) parameterized.push(definition.name)
     }
 
-    expect(rendered).toHaveLength(28)
+    expect(rendered).toHaveLength(29)
     expect(redirects).toEqual([
       'profile-totp',
       'profile-shortcuts',
@@ -337,7 +337,7 @@ describe('sdílená klientská plocha vlastní domény', () => {
     }
     expect(Object.fromEntries(kindCounts)).toEqual({
       client_redirect: 3,
-      permission: 22,
+      permission: 23,
       router_redirect: 8,
       self_service: 3,
     })
@@ -441,7 +441,7 @@ describe('sdílená klientská plocha vlastní domény', () => {
 
   it('pokrývá každý literální cíl klientské navigace manifestem a routerem', () => {
     const paths = [...new Set(clientNavigationPaths())]
-    expect(paths).toHaveLength(13)
+    expect(paths).toHaveLength(14)
 
     const routeNames = new Set(clientDomainRoutes.map(route => route.name))
     for (const path of paths) {
@@ -457,6 +457,7 @@ describe('sdílená klientská plocha vlastní domény', () => {
       'invoice-new',
       'invoices',
       'portal',
+      'portal-company-settings',
       'portal-document-requests',
       'portal-purchase-invoice-submissions',
       'purchase-invoice-new',

--- a/web/tests/custom-domain-client-surface.test.mjs
+++ b/web/tests/custom-domain-client-surface.test.mjs
@@ -14,11 +14,10 @@ const lock = await readFile(new URL('components/SessionLockOverlay.vue', src), '
 const client = await readFile(new URL('api/client.ts', src), 'utf8')
 
 test('shared manifest persists the audited client surface and legacy aliases', () => {
-  // 36 = 35 auditovaných + self-service `isds-gateway-callback` (viz commit, který
-  // routu do manifestu přidal). Je to brána proti nechtěnému rozšíření klientské
-  // plochy, ne konstanta — s každou novou routou se čísla vědomě posouvají.
-  assert.equal(manifest.routes.length, 36)
-  assert.equal(new Set(manifest.routes.map(route => route.name)).size, 36)
+  // Přesný počet je brána proti nechtěnému rozšíření klientské plochy, ne
+  // konstanta — s každou novou auditovanou routou se vědomě posouvá.
+  assert.equal(manifest.routes.length, 37)
+  assert.equal(new Set(manifest.routes.map(route => route.name)).size, 37)
   assert.deepEqual(
     manifest.routes.slice(-3).map(route => route.name),
     ['data-exchange', 'admin-export', 'admin-import'],


### PR DESCRIPTION
# Delegované provozní nastavení firmy pro klientské role

Closes #20

## Shrnutí

Klientská role může spravovat vybrané provozní nastavení aktuální firmy prostřednictvím existujícího oprávnění Nastavení firmy = Zápis.

Nevzniká nová pevná role ClientAdmin. Výchozí klientská role zůstává na úrovni Čtení, takže se její dosavadní chování nemění.

## Rozsah změn

- Nová klientská stránka Firma → Nastavení firmy.
- Správa odesílacích profilů:
- odesílatel a Reply-To,
- DKIM,
- SMTP a IMAP,
- testovací odeslání a kontrola IMAP.

- Správa brandingu:
- logo a akcentní barva,
- brandingové profily,
- kontaktní údaje a patička komunikace,
- přiřazení odesílacího profilu.

- Podpora klientských vlastních domén.
- Oprávnění lze přepsat samostatně pro každou firmu.

## Autorizační model

Klient získá přístup pouze při současném splnění:

1. efektivní role je typu client,
2. settings.company má úroveň WRITE,
3. požadavek míří na explicitní klientský allowlist /api/settings/client/*.

Interní oprávnění settings.company.write a settings.branding klientský typ použít nemůže ani při nekonzistentním záznamu v matici práv.

## Bezpečnostní omezení

Klient nemůže měnit:

- obchodní a právní údaje dodavatele,
- IČ, DIČ, DPH a účetní režim,
- bankovní účty a číslování dokladů,
- integrace, AI přístupové údaje, uživatele ani role,
- systémový sendmail,
- profily používající kryptografický S/MIME podpis.

Další pojistky:

- všechny operace používají firmu z ověřeného supplier contextu,
- SMTP a IMAP hesla jsou write-only a API je nikdy nevrací,
- auditní záznamy neobsahují tajné hodnoty,
- změny brandingu a profilů se zapisují do historie akcí,
- vazba brandingového profilu na odesílací profil se ověřuje vůči aktuální firmě,
- neznámá pole v klientském nastavení brandingu jsou odmítnuta,
- klient s úrovní Čtení neuvidí stránku ani data brandingových profilů.

## Kompatibilita

- Beze změny databázového schématu.
- Stávající administrátorské routy zůstávají zachované.
- Výchozí klientský preset zůstává settings.company = READ.
- Veřejné read-only API se nemění; nové endpointy slouží internímu UI.

## Dokumentace

Aktualizovány kapitoly:

- manual/09_Klientsky_portal.md
- manual/92_Nastaveni.md

HTML manuálu byl lokálně regenerován.

## Ověření

- npm run build
- npm exec vitest run src/security/__tests__/clientRoutePolicy.spec.ts
- node --test tests/custom-domain-client-surface.test.mjs
- cílené autorizační PHPUnit testy: 69 testů / 648 asercí
- HTTP RBAC integrační scénář: 7 testů
- Architecture suite: 276 testů / 5 841 asercí
- celá Unit sada: 6 143 testů prošlo; jediný nesouvisející JMHZ XLSX podproces narazil na výchozí limit 128 MB a při samostatném spuštění s memory_limit=512M prošel 5/5 testů.
