### PR TITLE
fix(web): self-hostované fonty musí projít i přes Apache a nginx

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -79,6 +79,15 @@ Options -Indexes -MultiViews
     RewriteCond %{REQUEST_URI} ^/assets/
     RewriteRule ^assets/(.*)$ web/dist/assets/$1 [L]
 
+    # 3a-2) /fonts/* → web/dist/fonts/* (self-hostované woff2 z web/public/fonts,
+    # které `web/index.html` preloaduje absolutní cestou `/fonts/…`). Bez tohoto
+    # pravidla je spolkne SPA fallback (pravidlo 4) a vrátí index.html s Content-Type
+    # text/html — prohlížeč font zahodí (`OTS parsing error: invalid sfntVersion`,
+    # 0x3C21444F = "<!DO") a celá aplikace spadne na systémový fallback.
+    # V IIS to řeší pravidlo „Self-hosted fonts" ve web.config, v nginxu blok 3a-2.
+    RewriteCond %{REQUEST_URI} ^/fonts/
+    RewriteRule ^fonts/(.*)$ web/dist/fonts/$1 [L]
+
     # 3b) PWA soubory generované Vitem → web/dist. Service worker musí být
     # dostupný z rootu, aby mohl ovládat celou aplikaci (scope `/`).
     RewriteRule ^service-worker\.js$ web/dist/service-worker.js [E=NOCACHE:1,L]

--- a/api/tests/Architecture/SelfHostedFontRoutingParityTest.php
+++ b/api/tests/Architecture/SelfHostedFontRoutingParityTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Architecture;
+
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Self-hostované fonty musí být dosažitelné na VŠECH třech webserverech.
+ *
+ * `web/index.html` preloaduje woff2 absolutní cestou `/fonts/…`, ale skutečné
+ * soubory leží v `web/dist/fonts/` (Vite je tam kopíruje z `web/public/fonts`).
+ * Každý webserver proto potřebuje vlastní alias — jinak požadavek spadne do SPA
+ * fallbacku, vrátí se index.html s Content-Type `text/html` a prohlížeč font
+ * TIŠE zahodí (`OTS parsing error: invalid sfntVersion: 1008821359`, což je
+ * 0x3C21444F, tedy `<!DO`). Aplikace pak celá běží v systémovém fontu.
+ *
+ * ⚠️ Chyba se neprojeví ve vývoji: `pnpm dev` servíruje `web/public/` z rootu,
+ * takže `/fonts/…` tam funguje bez jakéhokoli pravidla. Rozejde se to až
+ * v nasazení — a jen vzhledem, takže si toho nikdo nemusí všimnout. Právě proto
+ * je to hlídané testem, a ne jen komentářem u pravidla.
+ */
+final class SelfHostedFontRoutingParityTest extends TestCase
+{
+    /** Reprezentativní preloadovaný font — stačí jeden, pravidla jsou prefixová. */
+    private const SAMPLE_URI = '/fonts/geist-latin.woff2';
+
+    public function testIndexPreloadsFontsFromAbsolutePath(): void
+    {
+        $index = self::read(self::repoRoot() . '/web/index.html');
+        preg_match_all(
+            '#<link[^>]+rel="preload"[^>]+href="(/fonts/[^"]+\.woff2)"#',
+            $index,
+            $matches,
+        );
+
+        self::assertNotEmpty(
+            $matches[1],
+            'web/index.html musí preloadovat self-hostované fonty z /fonts/ — jinak tenhle test hlídá pravidlo, které už nikdo nepotřebuje.',
+        );
+        self::assertContains(
+            self::SAMPLE_URI,
+            $matches[1],
+            'Vzorová cesta testu se rozešla s index.html; sjednoť SAMPLE_URI.',
+        );
+
+        // Zdrojové soubory pro build. Bez nich by aliasy mířily do prázdna
+        // a všechny tři konfigurace by vracely 404 místo fontu.
+        foreach ($matches[1] as $uri) {
+            $source = self::repoRoot() . '/web/public' . $uri;
+            self::assertFileExists(
+                $source,
+                "Preloadovaný font {$uri} nemá zdroj v web/public/fonts/.",
+            );
+        }
+    }
+
+    public function testApacheRewritesFontsIntoDist(): void
+    {
+        $configuration = self::read(self::repoRoot() . '/.htaccess');
+        preg_match_all(
+            '/^\s*RewriteRule\s+(\S+)\s+(\S+)\s+\[([^\]]+)]\s*$/m',
+            $configuration,
+            $rules,
+            PREG_SET_ORDER,
+        );
+
+        $path = ltrim(self::SAMPLE_URI, '/');
+        $rewritten = null;
+        $fallbackIndex = null;
+        foreach ($rules as $index => $rule) {
+            // SPA fallback posílá na front controller všechno, co není reálný
+            // soubor — pravidlo pro fonty tedy musí být PŘED ním.
+            //
+            // ⚠️ Bere se POSLEDNÍ takové pravidlo, ne první. Na front controller
+            // míří i zámek údržby (pravidlo 2d), a ten stojí před statikou
+            // ZÁMĚRNĚ: v údržbě má i font dostat 503 z PHP, ne se odbavit
+            // webserverem. Kontrola na první shodu by tenhle správný stav
+            // hlásila jako chybu.
+            if ($rule[2] === 'api/public/index.php'
+                && preg_match('#' . $rule[1] . '#D', $path) === 1
+            ) {
+                $fallbackIndex = $index;
+            }
+            if ($rewritten === null
+                && preg_match('#' . $rule[1] . '#D', $path) === 1
+                && str_starts_with($rule[2], 'web/dist/fonts/')
+            ) {
+                $rewritten = $index;
+            }
+        }
+
+        self::assertNotNull(
+            $rewritten,
+            'Apache musí /fonts/* přepsat na web/dist/fonts/* — jinak je spolkne SPA fallback.',
+        );
+        if ($fallbackIndex !== null) {
+            self::assertLessThan(
+                $fallbackIndex,
+                $rewritten,
+                'Přepis fontů musí v .htaccess předcházet SPA fallbacku.',
+            );
+        }
+    }
+
+    public function testNginxAliasesFontsIntoDist(): void
+    {
+        $configuration = self::read(self::repoRoot() . '/docker/nginx.conf');
+
+        self::assertSame(
+            1,
+            preg_match(
+                '#location\s+\^~\s+/fonts/\s*\{([^{}]*)\}#s',
+                $configuration,
+                $location,
+            ),
+            'nginx musí mít prefixový location ^~ /fonts/ — jinak požadavek spadne do location / a odtud na @spa.',
+        );
+        self::assertMatchesRegularExpression(
+            '#\balias\s+/var/www/html/web/dist/fonts/\s*;#',
+            $location[1],
+            'nginx location /fonts/ musí aliasovat do web/dist/fonts/.',
+        );
+        self::assertMatchesRegularExpression(
+            '#\btry_files\s+\$uri\s+=404\s*;#',
+            $location[1],
+            'Chybějící font musí skončit 404, ne tichým průchodem na SPA.',
+        );
+
+        self::assertStringContainsString(
+            'COPY docker/nginx.conf /etc/nginx/nginx.conf',
+            self::read(self::repoRoot() . '/Dockerfile.alpine'),
+            'Alpine image musí testovanou nginx konfiguraci skutečně instalovat.',
+        );
+    }
+
+    public function testIisRewritesFontsIntoDist(): void
+    {
+        $document = new DOMDocument();
+        self::assertTrue(
+            $document->load(self::repoRoot() . '/web.config', LIBXML_NONET),
+            'IIS web.config není platné XML.',
+        );
+        $xpath = new DOMXPath($document);
+        $rules = $xpath->query('//system.webServer/rewrite/rules/rule');
+        self::assertNotFalse($rules);
+
+        $path = ltrim(self::SAMPLE_URI, '/');
+        $rewriteIndex = null;
+        $fallbackIndex = null;
+        foreach ($rules as $index => $rule) {
+            self::assertInstanceOf(DOMElement::class, $rule);
+            if ($rule->getAttribute('name') === 'SPA fallback') {
+                $fallbackIndex ??= $index;
+            }
+
+            $match = $rule->getElementsByTagName('match')->item(0);
+            $action = $rule->getElementsByTagName('action')->item(0);
+            if (!$match instanceof DOMElement || !$action instanceof DOMElement) {
+                continue;
+            }
+            if ($rewriteIndex === null
+                && $action->getAttribute('type') === 'Rewrite'
+                && str_starts_with($action->getAttribute('url'), 'web/dist/fonts/')
+                && preg_match('#' . $match->getAttribute('url') . '#D', $path) === 1
+            ) {
+                $rewriteIndex = $index;
+            }
+        }
+
+        self::assertNotNull($rewriteIndex, 'IIS musí /fonts/* přepsat na web/dist/fonts/*.');
+        self::assertNotNull($fallbackIndex, 'IIS konfigurace nemá očekávaný SPA fallback.');
+        self::assertLessThan($fallbackIndex, $rewriteIndex, 'Přepis fontů musí předcházet SPA fallbacku.');
+    }
+
+    private static function repoRoot(): string
+    {
+        return dirname(__DIR__, 3);
+    }
+
+    private static function read(string $path): string
+    {
+        $contents = file_get_contents($path);
+        self::assertIsString($contents, "Nelze načíst {$path}.");
+        // .htaccess, nginx.conf ani index.html nemají v .gitattributes vynucené
+        // LF, takže Windows checkout (core.autocrlf) je dostane s CRLF.
+        return str_replace("\r\n", "\n", $contents);
+    }
+}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -164,6 +164,19 @@ http {
             try_files $uri =404;
         }
 
+        # ---- 3a-2) /fonts/* → web/dist/fonts/* ------------------------------
+        # Self-hostované woff2 z `web/public/fonts`, které `web/index.html`
+        # preloaduje absolutní cestou `/fonts/…`. Bez tohoto bloku je spolkne
+        # `location /` → `@spa` a vrátí index.html s Content-Type text/html —
+        # prohlížeč font zahodí (`OTS parsing error: invalid sfntVersion`,
+        # 0x3C21444F = "<!DO") a celá aplikace spadne na systémový fallback.
+        # Parita s .htaccess (3a-2) a web.config („Self-hosted fonts").
+        location ^~ /fonts/ {
+            alias /var/www/html/web/dist/fonts/;
+            access_log off;
+            try_files $uri =404;
+        }
+
         # ---- 3b) PWA soubory z Vite dist ----------------------------------
         location = /service-worker.js {
             alias /var/www/html/web/dist/service-worker.js;


### PR DESCRIPTION
## Co se mění

Self-hostované fonty nejsou v nasazení dosažitelné přes Apache ani nginx — vrací se na ně `index.html`.

`web/index.html` je preloaduje absolutní cestou:

```html
<link rel="preload" href="/fonts/geist-latin.woff2" as="font" type="font/woff2" crossorigin />
```

Skutečné soubory ale leží v `web/dist/fonts/` (Vite je tam kopíruje z `web/public/fonts`). Alias `/fonts/*` → `web/dist/fonts/*` má proto jen IIS — pravidlo „Self-hosted fonts" ve `web.config`, které tenhle přesný failure mode i popisuje v komentáři. V `.htaccess` a `docker/nginx.conf` chybí, takže tam požadavek propadne až do SPA fallbacku.

Výsledek v běžícím Docker stacku (`myucto:latest`, 6.1.0) **před** opravou:

```
$ curl -sI localhost:8088/fonts/geist-latin.woff2
status=200  content-type: text/html; charset=utf-8  size=3130      ← index.html

konzole prohlížeče:
  Failed to decode downloaded font: /fonts/geist-latin.woff2
  OTS parsing error: invalid sfntVersion: 1008821359
```

`1008821359` = `0x3C21444F` = `<!DO` — prohlížeč parsuje začátek HTML jako hlavičku fontu, tiše ho zahodí a celá aplikace běží v systémovém fallbacku.

## Proč to nikdo nechytil

`pnpm dev` servíruje `web/public/` z rootu, takže `/fonts/…` ve vývoji funguje bez jakéhokoli pravidla. Rozejde se to až v nasazení — a jen vzhledem, žádná chyba, žádný nefunkční prvek. Proto k opravě přidávám guard test, ne jen komentář u pravidla.

## Jak je to opravené

- `.htaccess` — pravidlo 3a-2 hned za `/assets/` (a tedy **za** zámkem údržby 2d, aby i font v údržbě dostal 503 z PHP).
- `docker/nginx.conf` — blok 3a-2 `location ^~ /fonts/` s aliasem do `web/dist/fonts/` a `try_files $uri =404` (chybějící font má být 404, ne tichý průchod na SPA).
- `web.config` zůstává beze změny — pravidlo tam už bylo, nová je jen parita zbylých dvou.
- `api/tests/Architecture/SelfHostedFontRoutingParityTest.php` — hlídá všechny tři konfigurace najednou: že `index.html` fonty preloaduje, že mají zdroj v `web/public/fonts/`, a že každý webserver má odpovídající alias **před** SPA fallbackem.

## Jak jsem to testoval

**Guard test chytá původní stav** — se zrevertovanými konfiguracemi padá přesně na dvou místech, kde chyběla pravidla, a IIS větev prochází i tak:

```
1) SelfHostedFontRoutingParityTest::testApacheRewritesFontsIntoDist
   Apache musí /fonts/* přepsat na web/dist/fonts/* — jinak je spolkne SPA fallback.
2) SelfHostedFontRoutingParityTest::testNginxAliasesFontsIntoDist
   nginx musí mít prefixový location ^~ /fonts/ …
Tests: 4, Assertions: 29, Failures: 2
```

S opravou: `OK (4 tests, 34 assertions)`.

**Ostré ověření v Docker stacku** (nginx reload s novou konfigurací):

```
$ curl -sI localhost:8088/fonts/geist-latin.woff2
status=200  content-type: font/woff2  size=29400        ← sedí s velikostí souboru
$ curl -s localhost:8088/fonts/geist-latin.woff2 | head -c 4 | xxd
00000000: 774f 4632    wOF2                             ← platná woff2 signatura
$ curl -sI localhost:8088/fonts/neexistuje.woff2
status=404                                              ← ne SPA fallback
```

Konzole prohlížeče na `/setup` je po opravě čistá (0 errors, 0 warnings; předtím 4 warnings) a stránka se vykresluje v Geistu.

**Sady:**

- `vendor/bin/phpunit --testsuite Architecture` — OK, 317 testů / 7020 asercí (2 skipped)
- `vendor/bin/phpunit` (plná sada) — 14 967 testů / 82 764 asercí, 48 skipped, **19 errorů + 1 failure**

  Ty errory a failure **nezpůsobuje tahle změna** — ověřil jsem to spuštěním týchž tříd na čistém masteru bez ní, kde padají identicky:

  - 19× `Call to undefined function cal_days_in_month()` v `PayrollPostingReconciliationServiceTest` — `myucto:latest` neinstaluje `ext-calendar` (v `Dockerfile.alpine` ve výčtu `install-php-extensions` není, stejně tak ne v `extensions:` v `ci.yml`). Volá se to jen z testu, produkční kód `cal_days_in_month()` nikde nepoužívá — je to skrytá závislost testovací sady na rozšíření, které projekt sám nedistribuuje.
  - 1× `InstanceExportConcurrencyAndRetentionTest::testFileLockRefusesSecondRunnerAndReleases` — test souběžného `flock`, u mě přes bind mount na macOS. Nesouvisí se změnou.

  Nehlásím to jako součást PR, jen ať je jasné, co v tom výpisu je a co ne.
- `pnpm build` (= `vue-tsc --noEmit && vite build`) — OK, prošlo; build zároveň potvrdil, že Vite kopíruje `web/public/fonts` → `web/dist/fonts` (všech 6 woff2), což je premisa toho aliasu.

Testováno na PHP 8.5.9 / PHPUnit 13.3.1 v `myucto:latest`, DB MariaDB 11.8 podle receptu z `.github/workflows/ci.yml`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRK8mHAJg2sx5B5S8PWeKH
