### PR TITLE
fix(users): otevřít nabídku firem až při vyhledávání

### DIFF
--- a/manual/92_Nastaveni.md
+++ b/manual/92_Nastaveni.md
@@ -267,7 +267,8 @@ nepřepsali nastavení.
 
 Každý uživatel kromě superadmina má přístup pouze k firmám, které mu
 superadmin výslovně přidá v editaci uživatele. Firma se vyhledá podle názvu,
-IČO nebo ID; aplikace kvůli tomu nenačítá celý seznam firem.
+IČO nebo ID; aplikace kvůli tomu nenačítá celý seznam firem. Nabídka firem se
+otevře po vstupu do vyhledávacího pole a po opuštění pole se zase zavře.
 
 U přiřazené firmy lze ponechat **Výchozí roli**, nebo vybrat jinou aktivní roli
 stejného typu. Přepis se s výchozí rolí nesčítá — pro danou firmu ji úplně

--- a/web/src/pages/admin/Users.vue
+++ b/web/src/pages/admin/Users.vue
@@ -37,6 +37,7 @@ const supplierSearchOpen = ref(false)
 const supplierCursor = ref<string | null>(null)
 const assignments = ref<Array<UserSupplierAssignment & { role_id: number | null }>>([])
 let searchTimer: ReturnType<typeof setTimeout> | undefined
+let supplierSearchGeneration = 0
 
 const form = reactive({ id: null as number | null, email: '', name: '', role_id: 0, locale: 'cs' as 'cs' | 'en', is_active: true, password: '' })
 const selectedRole = computed(() => roles.value.find(r => r.id === form.role_id) ?? null)
@@ -63,8 +64,10 @@ async function load() {
 
 function resetSupplierSearch() {
   clearTimeout(searchTimer)
+  supplierSearchGeneration++
   supplierQuery.value = ''
   supplierResults.value = []
+  supplierSearching.value = false
   supplierCursor.value = null
   supplierSearchOpen.value = false
 }
@@ -85,13 +88,25 @@ async function openEdit(user: AdminUser) {
 }
 
 async function searchSuppliers(query: string, append: boolean) {
+  const normalizedQuery = query.trim()
+  if (normalizedQuery.length === 1 && !/^\d$/.test(normalizedQuery)) {
+    supplierResults.value = []
+    supplierCursor.value = null
+    supplierSearching.value = false
+    return
+  }
+  const generation = ++supplierSearchGeneration
+  const cursor = append ? supplierCursor.value : null
   supplierSearching.value = true
   try {
-    const response = await adminApi.searchSuppliers({ q: query || undefined, limit: 20, ...(append && supplierCursor.value ? { cursor: supplierCursor.value } : {}) })
+    const response = await adminApi.searchSuppliers({ q: normalizedQuery || undefined, limit: 20, ...(cursor ? { cursor } : {}) })
+    if (generation !== supplierSearchGeneration || !supplierSearchOpen.value || normalizedQuery !== supplierQuery.value.trim()) return
     const available = response.data.filter(s => !assignments.value.some(a => a.supplier_id === s.id))
     supplierResults.value = append ? [...supplierResults.value, ...available] : available
     supplierCursor.value = response.next_cursor
-  } finally { supplierSearching.value = false }
+  } finally {
+    if (generation === supplierSearchGeneration) supplierSearching.value = false
+  }
 }
 
 function openSupplierSearch() {
@@ -102,12 +117,21 @@ function openSupplierSearch() {
 function closeSupplierSearch() {
   supplierSearchOpen.value = false
   clearTimeout(searchTimer)
+  supplierSearchGeneration++
+  supplierSearching.value = false
 }
 
 watch(supplierQuery, query => {
   clearTimeout(searchTimer)
+  supplierSearchGeneration++
+  supplierSearching.value = false
   if (!supplierSearchOpen.value) return
-  if (query.length === 1) { supplierResults.value = []; return }
+  const normalizedQuery = query.trim()
+  if (normalizedQuery.length === 1 && !/^\d$/.test(normalizedQuery)) {
+    supplierResults.value = []
+    supplierCursor.value = null
+    return
+  }
   searchTimer = setTimeout(() => { void searchSuppliers(query, false) }, 275)
 })
 

--- a/web/src/pages/admin/Users.vue
+++ b/web/src/pages/admin/Users.vue
@@ -33,6 +33,7 @@ const error = ref('')
 const supplierQuery = ref('')
 const supplierResults = ref<AdminSupplierSearchItem[]>([])
 const supplierSearching = ref(false)
+const supplierSearchOpen = ref(false)
 const supplierCursor = ref<string | null>(null)
 const assignments = ref<Array<UserSupplierAssignment & { role_id: number | null }>>([])
 let searchTimer: ReturnType<typeof setTimeout> | undefined
@@ -60,19 +61,27 @@ async function load() {
   finally { loading.value = false }
 }
 
+function resetSupplierSearch() {
+  clearTimeout(searchTimer)
+  supplierQuery.value = ''
+  supplierResults.value = []
+  supplierCursor.value = null
+  supplierSearchOpen.value = false
+}
+
 function openCreate() {
+  resetSupplierSearch()
   const initial = roles.value.find(r => r.is_active && r.role_type === 'staff' && r.system_key !== 'superadmin') ?? roles.value.find(r => r.is_active)
   Object.assign(form, { id: null, email: '', name: '', role_id: initial?.id ?? 0, locale: 'cs', is_active: true, password: '' })
   assignments.value = []
   showForm.value = true
-  void searchSuppliers('', false)
 }
 
 async function openEdit(user: AdminUser) {
+  resetSupplierSearch()
   Object.assign(form, { id: user.id, email: user.email, name: user.name, role_id: user.role_id || user.role.id, locale: user.locale, is_active: user.is_active, password: '' })
   assignments.value = user.is_superadmin ? [] : (await adminApi.listUserSuppliers(user.id)).map(a => ({ ...a, role_id: a.role_id }))
   showForm.value = true
-  void searchSuppliers('', false)
 }
 
 async function searchSuppliers(query: string, append: boolean) {
@@ -85,8 +94,19 @@ async function searchSuppliers(query: string, append: boolean) {
   } finally { supplierSearching.value = false }
 }
 
+function openSupplierSearch() {
+  supplierSearchOpen.value = true
+  void searchSuppliers(supplierQuery.value, false)
+}
+
+function closeSupplierSearch() {
+  supplierSearchOpen.value = false
+  clearTimeout(searchTimer)
+}
+
 watch(supplierQuery, query => {
   clearTimeout(searchTimer)
+  if (!supplierSearchOpen.value) return
   if (query.length === 1) { supplierResults.value = []; return }
   searchTimer = setTimeout(() => { void searchSuppliers(query, false) }, 275)
 })
@@ -172,7 +192,32 @@ onMounted(load)
             <select v-model.number="item.role_id" class="h-9 px-2 border border-neutral-300 rounded-md bg-surface text-sm"><option :value="null">{{ t('users.supplier_role_inherit') }}</option><option v-for="role in compatibleRoles" :key="role.id" :value="role.id">{{ role.name }}</option></select>
             <button type="button" :class="btnOutline('danger')" @click="assignments.splice(index,1)">{{ t('common.remove') }}</button>
           </div>
-          <div class="relative"><input v-model="supplierQuery" :placeholder="t('users.supplier_search')" class="w-full h-10 px-3 border border-neutral-300 rounded-md" /><div v-if="supplierSearching" class="text-xs text-neutral-500 mt-1">{{ t('common.loading') }}</div><div v-if="supplierResults.length" class="absolute z-10 top-full inset-x-0 max-h-64 overflow-y-auto bg-surface border border-neutral-200 rounded-md shadow-lg"><button v-for="item in supplierResults" :key="item.id" type="button" class="block w-full text-left px-3 py-2 hover:bg-neutral-50" @click="addSupplier(item)">{{ item.name }} <span v-if="item.ic" class="text-xs text-neutral-500">({{ item.ic }})</span></button><button v-if="supplierCursor" type="button" class="block w-full px-3 py-2 text-sm text-primary-600 hover:bg-primary-50" @click="searchSuppliers(supplierQuery, true)">{{ t('users.supplier_more') }}</button></div></div>
+          <div class="relative">
+            <input
+              v-model="supplierQuery"
+              type="text"
+              role="combobox"
+              autocomplete="off"
+              aria-autocomplete="list"
+              :aria-expanded="supplierSearchOpen"
+              :aria-controls="supplierSearchOpen ? 'user-supplier-search-results' : undefined"
+              :placeholder="t('users.supplier_search')"
+              class="w-full h-10 px-3 border border-neutral-300 rounded-md"
+              @focus="openSupplierSearch"
+              @blur="closeSupplierSearch"
+            />
+            <div v-if="supplierSearchOpen && supplierSearching" class="text-xs text-neutral-500 mt-1">{{ t('common.loading') }}</div>
+            <div
+              v-if="supplierSearchOpen && supplierResults.length"
+              id="user-supplier-search-results"
+              role="listbox"
+              class="absolute z-10 top-full inset-x-0 max-h-64 overflow-y-auto bg-surface border border-neutral-200 rounded-md shadow-lg"
+              @mousedown.prevent
+            >
+              <button v-for="item in supplierResults" :key="item.id" type="button" role="option" class="block w-full text-left px-3 py-2 hover:bg-neutral-50" @click="addSupplier(item)">{{ item.name }} <span v-if="item.ic" class="text-xs text-neutral-500">({{ item.ic }})</span></button>
+              <button v-if="supplierCursor" type="button" class="block w-full px-3 py-2 text-sm text-primary-600 hover:bg-primary-50" @click="searchSuppliers(supplierQuery, true)">{{ t('users.supplier_more') }}</button>
+            </div>
+          </div>
           <p v-if="supplierRequired" class="rounded-md bg-danger-50 px-3 py-2 text-sm text-danger-600">
             {{ t('users.supplier_required') }}
           </p>

--- a/web/src/pages/admin/__tests__/UsersSupplierSearch.spec.ts
+++ b/web/src/pages/admin/__tests__/UsersSupplierSearch.spec.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+const m = vi.hoisted(() => ({
+  listUsers: vi.fn(),
+  listUserSuppliers: vi.fn(),
+  searchSuppliers: vi.fn(),
+  listRoles: vi.fn(),
+}))
+
+vi.mock('@/api/admin', () => ({
+  adminApi: {
+    listUsers: m.listUsers,
+    listUserSuppliers: m.listUserSuppliers,
+    searchSuppliers: m.searchSuppliers,
+  },
+}))
+
+vi.mock('@/api/roles', () => ({ rolesApi: { list: m.listRoles } }))
+vi.mock('@/composables/useToast', () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn(), warning: vi.fn() }),
+}))
+vi.mock('@/stores/auth', () => ({ useAuthStore: () => ({ newUserBlocked: null }) }))
+vi.mock('@/components/ui/buttonStyles', () => ({
+  ICONS: { plus: 'M0 0' },
+  btnOutline: () => 'btn-outline',
+  btnFilled: () => 'btn-filled',
+}))
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+
+import Users from '../Users.vue'
+
+const clientRole = {
+  id: 2,
+  system_key: null,
+  name: 'Klient – Admin',
+  role_type: 'client',
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  default_usage: 1,
+  override_usage: 0,
+}
+
+const user = {
+  id: 7,
+  email: 'klient@example.test',
+  name: 'Testovací klient',
+  role_id: clientRole.id,
+  role: { id: clientRole.id, name: clientRole.name, type: 'client', system_key: null },
+  locale: 'cs',
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  last_login_at: null,
+}
+
+describe('Uživatelé — vyhledání přiřazené firmy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    m.listUsers.mockResolvedValue([user])
+    m.listRoles.mockResolvedValue([clientRole])
+    m.listUserSuppliers.mockResolvedValue([{
+      supplier_id: 10,
+      name: 'Přiřazená firma s.r.o.',
+      ic: '12345678',
+      role_id: null,
+      effective_role: user.role,
+    }])
+    m.searchSuppliers.mockResolvedValue({
+      data: [{ id: 20, name: 'Další firma s.r.o.', ic: '87654321' }],
+      next_cursor: null,
+    })
+  })
+
+  it('nabídku zobrazí až po focusu a po opuštění pole ji zase skryje', async () => {
+    const wrapper = mount(Users)
+    await flushPromises()
+
+    const edit = wrapper.findAll('button').find(button => button.text() === 'common.edit')
+    expect(edit).toBeDefined()
+    await edit!.trigger('click')
+    await flushPromises()
+
+    const input = wrapper.get('input[placeholder="users.supplier_search"]')
+    const result = () => wrapper.findAll('button').find(button => button.text().includes('Další firma s.r.o.'))
+
+    expect(result()).toBeUndefined()
+    expect(m.searchSuppliers).not.toHaveBeenCalled()
+
+    await input.trigger('focus')
+    await flushPromises()
+    expect(result()).toBeDefined()
+    expect(m.searchSuppliers).toHaveBeenCalledTimes(1)
+
+    await input.trigger('blur')
+    expect(result()).toBeUndefined()
+  })
+})

--- a/web/src/pages/admin/__tests__/UsersSupplierSearch.spec.ts
+++ b/web/src/pages/admin/__tests__/UsersSupplierSearch.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 
 const m = vi.hoisted(() => ({
@@ -30,6 +30,12 @@ vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
 
 import Users from '../Users.vue'
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(resolver => { resolve = resolver })
+  return { promise, resolve }
+}
+
 const clientRole = {
   id: 2,
   system_key: null,
@@ -56,6 +62,7 @@ const user = {
 
 describe('Uživatelé — vyhledání přiřazené firmy', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     vi.clearAllMocks()
     m.listUsers.mockResolvedValue([user])
     m.listRoles.mockResolvedValue([clientRole])
@@ -72,16 +79,25 @@ describe('Uživatelé — vyhledání přiřazené firmy', () => {
     })
   })
 
-  it('nabídku zobrazí až po focusu a po opuštění pole ji zase skryje', async () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  async function openEditForm() {
     const wrapper = mount(Users)
     await flushPromises()
-
     const edit = wrapper.findAll('button').find(button => button.text() === 'common.edit')
     expect(edit).toBeDefined()
     await edit!.trigger('click')
     await flushPromises()
+    return {
+      wrapper,
+      input: wrapper.get('input[placeholder="users.supplier_search"]'),
+    }
+  }
 
-    const input = wrapper.get('input[placeholder="users.supplier_search"]')
+  it('nabídku zobrazí až po focusu a po opuštění pole ji zase skryje', async () => {
+    const { wrapper, input } = await openEditForm()
     const result = () => wrapper.findAll('button').find(button => button.text().includes('Další firma s.r.o.'))
 
     expect(result()).toBeUndefined()
@@ -94,5 +110,112 @@ describe('Uživatelé — vyhledání přiřazené firmy', () => {
 
     await input.trigger('blur')
     expect(result()).toBeUndefined()
+  })
+
+  it('starší odpověď nepřepíše novější dotaz ani nevypne jeho loading', async () => {
+    const older = deferred<{ data: Array<{ id: number; name: string; ic: string }>; next_cursor: null }>()
+    const newer = deferred<{ data: Array<{ id: number; name: string; ic: string }>; next_cursor: null }>()
+    m.searchSuppliers.mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise)
+    const { wrapper, input } = await openEditForm()
+
+    await input.setValue('stará')
+    await input.trigger('focus')
+    expect(m.searchSuppliers).toHaveBeenCalledTimes(1)
+
+    await input.setValue('nová')
+    await vi.advanceTimersByTimeAsync(275)
+    expect(m.searchSuppliers).toHaveBeenCalledTimes(2)
+    expect(wrapper.text()).toContain('common.loading')
+
+    older.resolve({ data: [{ id: 20, name: 'Starý výsledek', ic: '11111111' }], next_cursor: null })
+    await flushPromises()
+    expect(wrapper.text()).not.toContain('Starý výsledek')
+    expect(wrapper.text()).toContain('common.loading')
+
+    newer.resolve({ data: [{ id: 21, name: 'Nový výsledek', ic: '22222222' }], next_cursor: null })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Nový výsledek')
+    expect(wrapper.text()).not.toContain('common.loading')
+  })
+
+  it('odpověď zneplatněná blurem nepřepíše výsledky po znovuotevření', async () => {
+    const beforeBlur = deferred<{ data: Array<{ id: number; name: string; ic: string }>; next_cursor: null }>()
+    const afterFocus = deferred<{ data: Array<{ id: number; name: string; ic: string }>; next_cursor: null }>()
+    m.searchSuppliers.mockReturnValueOnce(beforeBlur.promise).mockReturnValueOnce(afterFocus.promise)
+    const { wrapper, input } = await openEditForm()
+
+    await input.setValue('firma')
+    await input.trigger('focus')
+    await input.trigger('blur')
+    await input.trigger('focus')
+    expect(m.searchSuppliers).toHaveBeenCalledTimes(2)
+
+    beforeBlur.resolve({ data: [{ id: 20, name: 'Výsledek před blurem', ic: '11111111' }], next_cursor: null })
+    await flushPromises()
+    expect(wrapper.text()).not.toContain('Výsledek před blurem')
+    expect(wrapper.text()).toContain('common.loading')
+
+    afterFocus.resolve({ data: [{ id: 21, name: 'Aktuální výsledek', ic: '22222222' }], next_cursor: null })
+    await flushPromises()
+    expect(wrapper.text()).toContain('Aktuální výsledek')
+  })
+
+  it('reset formuláře zneplatní rozpracované vyhledávání', async () => {
+    const pending = deferred<{ data: Array<{ id: number; name: string; ic: string }>; next_cursor: null }>()
+    m.searchSuppliers.mockReturnValueOnce(pending.promise)
+    const { wrapper, input } = await openEditForm()
+
+    await input.setValue('firma')
+    await input.trigger('focus')
+    const create = wrapper.findAll('button').find(button => button.text() === 'users.new')
+    expect(create).toBeDefined()
+    await create!.trigger('click')
+
+    pending.resolve({ data: [{ id: 20, name: 'Výsledek před resetem', ic: '11111111' }], next_cursor: null })
+    await flushPromises()
+    expect(wrapper.get('input[placeholder="users.supplier_search"]').element).toHaveProperty('value', '')
+    expect(wrapper.text()).not.toContain('Výsledek před resetem')
+  })
+
+  it('jedno písmeno neposílá při watcheru ani refocusu, jednočíselné ID ano', async () => {
+    const { input } = await openEditForm()
+
+    await input.trigger('focus')
+    await flushPromises()
+    expect(m.searchSuppliers).toHaveBeenCalledTimes(1)
+
+    await input.setValue('a')
+    await vi.advanceTimersByTimeAsync(275)
+    await input.trigger('blur')
+    await input.trigger('focus')
+    expect(m.searchSuppliers).toHaveBeenCalledTimes(1)
+
+    await input.setValue('7')
+    await vi.advanceTimersByTimeAsync(275)
+    expect(m.searchSuppliers).toHaveBeenCalledTimes(2)
+    expect(m.searchSuppliers).toHaveBeenLastCalledWith({ q: '7', limit: 20 })
+  })
+
+  it('zachová načtení další stránky a výběr firmy kliknutím', async () => {
+    m.searchSuppliers
+      .mockResolvedValueOnce({ data: [{ id: 20, name: 'První firma', ic: '11111111' }], next_cursor: '20' })
+      .mockResolvedValueOnce({ data: [{ id: 21, name: 'Druhá firma', ic: '22222222' }], next_cursor: null })
+    const { wrapper, input } = await openEditForm()
+
+    await input.trigger('focus')
+    await flushPromises()
+    const more = wrapper.findAll('button').find(button => button.text() === 'users.supplier_more')
+    expect(more).toBeDefined()
+    await more!.trigger('click')
+    await flushPromises()
+    expect(m.searchSuppliers).toHaveBeenLastCalledWith({ limit: 20, cursor: '20' })
+    expect(wrapper.text()).toContain('První firma')
+    expect(wrapper.text()).toContain('Druhá firma')
+
+    const second = wrapper.findAll('button').find(button => button.text().includes('Druhá firma'))
+    expect(second).toBeDefined()
+    await second!.trigger('click')
+    expect(wrapper.text()).toContain('Druhá firma')
+    expect(wrapper.findAll('[role="option"]').some(option => option.text().includes('Druhá firma'))).toBe(false)
   })
 })


### PR DESCRIPTION
Editace klienta hned po otevření načetla prvních 20 dostupných firem a šablona je bez vlastního stavu otevření rovnou vykreslila. Absolutně umístěná nabídka proto překryla patičku dialogu s tlačítky Uložit a Zrušit, zvlášť u instalací s více firmami.

Našeptávač má nyní vlastní stav: požadavek se spouští až při focusu, nabídka se zobrazuje jen po dobu práce v poli a blur ji zavře. Mousedown uvnitř nabídky neodebere focus před clickem, takže výběr firmy i načtení další stránky zůstávají funkční. Při každém otevření formuláře se hledání resetuje.

Regresní test ověřuje, že před focusem se požadavek nepošle ani nabídka nezobrazí, po focusu se otevře a po blur zase zmizí. Ověřeno cíleným Vitest testem a kompletním frontendovým buildem; aktuální chování je doplněné také v manuálu.