### PR TITLE
fix(banka): opravit import PDF výpisu Raiffeisenbank

### DIFF
--- a/api/src/Service/Bank/Pdf/RaiffeisenbankStatementPdfParser.php
+++ b/api/src/Service/Bank/Pdf/RaiffeisenbankStatementPdfParser.php
@@ -37,8 +37,11 @@ final class RaiffeisenbankStatementPdfParser implements BankStatementPdfParserIn
     private const FX_RATE = '-?\d{1,3}(?:[\x{00A0} ]\d{3})*\.\d+';
     private const FX_RATE_LINE = '/^' . self::FX_RATE . '\s+[A-Z]{3}\/[A-Z]{3}$/u';
 
-    /** Hlavičkové zůstatky/součty: číslo s mezerami tisíců a tečkou (bez povinného znaménka). */
-    private const MONEY_H = '([\d\x{00A0} ]+\.\d{2})';
+    /** Hlavičkové zůstatky/součty: volitelné znaménko, mezery tisíců a desetinná tečka. */
+    private const MONEY_H = '(-?[\d\x{00A0} ]+\.\d{2})';
+
+    /** Za tímto textem RB rozepisuje složení poplatku, nikoli další bankovní pohyby. */
+    private const FEE_BREAKDOWN_START = 'V rámci souhrnné položky k účtu jsou zahrnuty poplatky';
 
     /**
      * Řádky, které v tabulce transakcí NEJSOU transakce — opakovaná záhlaví/hlavička
@@ -270,12 +273,20 @@ final class RaiffeisenbankStatementPdfParser implements BankStatementPdfParserIn
             $idx++;
         }
 
-        // Částka = POSLEDNÍ peněžní hodnota (s tečkou) ve zbytku slice, ale JEN ve měně účtu.
+        // Částka = POSLEDNÍ peněžní hodnota (s tečkou) před případným rozpisem
+        // souhrnného poplatku, ale JEN ve měně účtu.
         // Symboly/reference jsou celočíselné, takže „poslední s .dd" je jednoznačné; u kartové
         // platby v cizí měně se ale za CZK částkou tiskne ještě původní částka („-6.06 USD")
         // a kurz („21.83 CZK/USD") — obojí je nutné vynechat, jinak by amount = kurz (#205).
         $amount = null;
+        $inFeeBreakdown = false;
         for ($j = $idx; $j < $n; $j++) {
+            // Rozpis služeb patří do popisu stejné transakce, jeho dílčí hodnoty ale
+            // nesmějí přepsat hlavní účetní částku uvedenou před rozpisem.
+            if (str_starts_with($slice[$j], self::FEE_BREAKDOWN_START)) {
+                $inFeeBreakdown = true;
+            }
+            if ($inFeeBreakdown) continue;
             if (preg_match(self::FX_RATE_LINE, $slice[$j])) continue; // řádek kurzu, ne částka
             // Hodnota s volitelným měnovým sufixem; cizí měnu (např. USD) přeskoč, ber jen
             // částku bez sufixu nebo v měně účtu.

--- a/api/tests/Unit/Service/Bank/Pdf/RaiffeisenbankStatementPdfParserTest.php
+++ b/api/tests/Unit/Service/Bank/Pdf/RaiffeisenbankStatementPdfParserTest.php
@@ -66,6 +66,36 @@ final class RaiffeisenbankStatementPdfParserTest extends TestCase
         self::assertSame(1234.56, $header['debit_total']);
     }
 
+    public function testNegativeBalancesAndFeeBreakdownUseMainTransactionAmount(): void
+    {
+        $rows = "30. 6. 2026\n30. 6. 2026\n1000000005\n"
+              . "Poplatek\tVedení účtu\n"
+              . "KS:898\n"
+              . "Souhrnná položka k účtu 1000000005.\n"
+              . "898\t-49.00 CZK\n"
+              . "V rámci souhrnné položky k účtu jsou zahrnuty poplatky za následující služby:\n"
+              . "Přímé bankovnictví: 0.00 CZK\n"
+              . "Vedení běžného účtu v hlavní měně: 49.00 CZK\n"
+              . "Vedení spořicího účtu: 0.00 CZK\n";
+        $text = str_replace(
+            "Poplatky celkem:\t0.00",
+            "Poplatky celkem:\t999.00",
+            $this->statement('-100.00', '-149.00', '0.00', '49.00', $rows),
+        );
+
+        $result = $this->parser()->parse('%PDF-fake', $text);
+
+        self::assertSame(-100.0, $result['header']['prev_balance']);
+        self::assertSame(-149.0, $result['header']['curr_balance']);
+        self::assertSame(49.0, $result['header']['debit_total']);
+        self::assertCount(1, $result['transactions']);
+        self::assertSame(-49.0, $result['transactions'][0]['amount']);
+        self::assertStringContainsString(
+            'V rámci souhrnné položky k účtu jsou zahrnuty poplatky',
+            (string) $result['transactions'][0]['description'],
+        );
+    }
+
     public function testParsesIncomingPaymentWithCounterpartyName(): void
     {
         // Příchozí úhrada: Kategorie / účet / Název protiúčtu / Typ+částka (bez znaménka).


### PR DESCRIPTION
Parser nově podporuje záporný počáteční i konečný zůstatek. U souhrnné poplatkové transakce zachová její podrobný rozpis, ale dílčí částky už nepřepíšou hlavní částku bankovního pohybu.

Regresní test pokrývá záporné zůstatky, ignorování souhrnu poplatků z hlavičky a zachování rozpisu v popisu transakce.

backport https://github.com/radekhulan/myinvoice/pull/275