### PR TITLE
fix(ui): datumová pole faktur zadávat ve formátu jazyka aplikace

### DIFF
--- a/manual/15_Faktura_editor.md
+++ b/manual/15_Faktura_editor.md
@@ -44,6 +44,12 @@ Editor je rozdělený na tři bloky:
 | Číslo objednávky dodavatele | Volitelná obchodní reference, například `MYU000023`. Je uložená přímo na faktuře i bez zakázky a lze podle ní párovat platby. |
 | Datum úhrady | Vyplní se automaticky při zaplacení (přes banku nebo manuálně) |
 
+Datumová pole se zadávají ve formátu jazyka aplikace — v češtině `d. m. rrrr`
+(např. `1. 9. 2026` nebo zkráceně `1.9.26`), v angličtině `mm/dd/yyyy`. Formát
+se neřídí jazykem prohlížeče ani systému. Ikona vpravo v poli otevře kalendář;
+neplatné datum (např. `31. 2.`) pole označí a faktura se neuloží, dokud ho
+neopravíte.
+
 ### 15.2.4 Měna a DPH
 
 - **Měna** — předvyplní se z klienta (nebo zakázky), lze přepsat.

--- a/manual/23_Prijate_faktury.md
+++ b/manual/23_Prijate_faktury.md
@@ -147,6 +147,11 @@ Limity:
 | **Kurz k DUZP** | Pokud je měna ≠ CZK, **musíš zafixovat kurz**. Tlačítko „Načíst z ČNB" stáhne denní kurz k rozhodnému dni dokladu. Korunový doklad kurz nemá — když měnu přepneš na CZK, kurz i jeho datum se vyprázdní. Viz [§ 23.2.9](#2329-kurz-cizi-meny-a-jeho-prenacitani). |
 | **Reverse charge** | Zaškrtni, pokud je doklad B2B s přenesenou daňovou povinností (pořízení zboží z EU, služby z EU/3. země, tuzemský §92a). Položkám nastav **tuzemskou sazbu** (typicky 21 %) a odpovídající klasifikační kód — daň na dokladu zůstane 0 (dodavatel ji neúčtuje), samovyměření i zrcadlový odpočet dopočítají výkazy DPH. Viz [§ 23.2.7](#2327-reverse-charge-z-eu-porizeni-zbozi-vs-sluzba). |
 
+Datumová pole (vystaveno, DUZP, splatnost, datum přijetí i časové rozlišení
+u položek) se zadávají ve formátu jazyka aplikace — česky `d. m. rrrr`, anglicky
+`mm/dd/yyyy`, stejně jako u [vydaných faktur](15_Faktura_editor.md). Ikona v poli
+otevře kalendář.
+
 > [!NOTE]
 > **Datum přijetí a období odpočtu DPH.** U ručně založené (tzn. **ne** importované)
 > tuzemské přijaté faktury se datum přijetí počítá i do určení **období, ve kterém

--- a/web/src/components/ui/DateInput.spec.ts
+++ b/web/src/components/ui/DateInput.spec.ts
@@ -1,0 +1,331 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+
+// Locale musí být reaktivní ref — komponenta na jeho změnu přeformátuje text.
+const i18n = vi.hoisted(() => ({
+  locale: { value: 'cs' } as { value: string },
+}))
+
+vi.mock('vue-i18n', async () => {
+  const { ref } = await import('vue')
+  i18n.locale = ref('cs')
+  return {
+    useI18n: () => ({
+      locale: i18n.locale,
+      t: (key: string) => key,
+    }),
+  }
+})
+
+import DateInput from '@/components/ui/DateInput.vue'
+
+afterEach(() => {
+  i18n.locale.value = 'cs'
+  document.body.innerHTML = ''
+})
+
+const textField = (wrapper: ReturnType<typeof mount>) => wrapper.get<HTMLInputElement>('input[type="text"]')
+const nativeField = (wrapper: ReturnType<typeof mount>) => wrapper.get<HTMLInputElement>('input[type="date"]')
+
+describe('DateInput', () => {
+  it('zobrazí ISO hodnotu ve formátu jazyka aplikace, ne prohlížeče', async () => {
+    const wrapper = mount(DateInput, { props: { modelValue: '2026-09-01' } })
+    expect(textField(wrapper).element.value).toBe('01. 09. 2026')
+
+    i18n.locale.value = 'en'
+    await nextTick()
+    expect(textField(wrapper).element.value).toBe('09/01/2026')
+  })
+
+  it('český zápis emituje ISO už během psaní a na blur se kanonizuje', async () => {
+    const wrapper = mount(DateInput, { props: { modelValue: '' } })
+    const input = textField(wrapper)
+
+    await input.trigger('focus')
+    await input.setValue('1.9.2026')
+    expect(wrapper.emitted('update:modelValue')).toEqual([['2026-09-01']])
+    expect(input.element.value).toBe('1.9.2026')
+
+    await wrapper.setProps({ modelValue: '2026-09-01' })
+    // Model odpovídá tomu, co je napsané → nepřeformátovat pod kurzorem.
+    expect(input.element.value).toBe('1.9.2026')
+    await input.trigger('blur')
+    expect(input.element.value).toBe('01. 09. 2026')
+    expect(input.attributes('aria-invalid')).toBeUndefined()
+  })
+
+  it('anglický zápis čte měsíc před dnem', async () => {
+    i18n.locale.value = 'en'
+    const wrapper = mount(DateInput, { props: { modelValue: '' } })
+    await textField(wrapper).setValue('9/1/2026')
+    expect(wrapper.emitted('update:modelValue')).toEqual([['2026-09-01']])
+  })
+
+  it('dvouciferný rok se během psaní nepotvrdí („1.9.20" není rok 2020), doplní se až na blur', async () => {
+    const wrapper = mount(DateInput, { props: { modelValue: '' } })
+    const input = textField(wrapper)
+
+    await input.trigger('focus')
+    await input.setValue('1.9.20')
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    // Rozepsaný zápis se při psaní nečervená, jen drží formulář neodeslatelný.
+    expect(input.attributes('aria-invalid')).toBeUndefined()
+    expect(input.element.validity.customError).toBe(true)
+
+    await input.setValue('1.9.2026')
+    expect(wrapper.emitted('update:modelValue')).toEqual([['2026-09-01']])
+
+    // Kdo skončí u „1.9.26" a odejde, dostane 2026 — zkratka platí, jen ne uprostřed psaní.
+    await input.setValue('1.9.26')
+    expect(wrapper.emitted('update:modelValue')).toHaveLength(1)
+    await input.trigger('blur')
+    // Bez rodiče se prop nezmění, takže blur emituje znovu — podstatné je, že rok je 2026.
+    expect(wrapper.emitted('update:modelValue')).toEqual([['2026-09-01'], ['2026-09-01']])
+    expect(input.element.value).toBe('01. 09. 2026')
+    expect(input.element.validity.customError).toBe(false)
+  })
+
+  it('neplatné datum nic neuloží, po opuštění pole ho označí a shodí nativní validitu formuláře', async () => {
+    const wrapper = mount(DateInput, { props: { modelValue: '2026-09-01' } })
+    const input = textField(wrapper)
+
+    await input.trigger('focus')
+    await input.setValue('31.2.2026')
+    expect(input.attributes('aria-invalid')).toBeUndefined()
+    await input.trigger('blur')
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    expect(input.attributes('aria-invalid')).toBe('true')
+    expect(input.classes()).toContain('border-danger-500')
+    expect(input.element.validity.customError).toBe(true)
+    expect(input.element.validationMessage).toBe('common.date_input.invalid')
+    // Rozepsaný text zůstane, aby ho uživatel mohl opravit — nepřepíše se starou hodnotou.
+    expect(input.element.value).toBe('31.2.2026')
+  })
+
+  it('vymazání pole emituje prázdný řetězec (stejně jako nativní input)', async () => {
+    const wrapper = mount(DateInput, { props: { modelValue: '2026-09-01' } })
+    await textField(wrapper).setValue('')
+    expect(wrapper.emitted('update:modelValue')).toEqual([['']])
+  })
+
+  it('změna zvenčí přepíše text, ale ne uživateli pod rukama', async () => {
+    const wrapper = mount(DateInput, { props: { modelValue: '2026-09-01' } })
+    const input = textField(wrapper)
+
+    await wrapper.setProps({ modelValue: '2026-10-15' })
+    expect(input.element.value).toBe('15. 10. 2026')
+
+    await input.trigger('focus')
+    await input.setValue('1.1.')
+    await wrapper.setProps({ modelValue: '2026-12-24' })
+    expect(input.element.value).toBe('1.1.')
+  })
+
+  it('přepočet zvenčí se ukáže i v poli, které má fokus, ale nic rozepsaného', async () => {
+    // Scénář z editoru: fokus je ve Splatnosti, uživatel kalendářem změní Vystaveno,
+    // watcher přepočte splatnost — pole ji musí ukázat, jinak by ji blur přepsal.
+    const wrapper = mount(DateInput, { props: { modelValue: '2026-09-13' } })
+    const input = textField(wrapper)
+
+    await input.trigger('focus')
+    await wrapper.setProps({ modelValue: '2026-11-13' })
+    expect(input.element.value).toBe('13. 11. 2026')
+
+    await input.trigger('blur')
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    expect(input.element.value).toBe('13. 11. 2026')
+  })
+
+  it('změna zvenčí uvolní i blokaci validity po neplatném zápisu', async () => {
+    // Uživatel nechá ve Splatnosti „31.2.2026", pak vybere jiného klienta a editor
+    // splatnost přepočte. Pole musí ukázat nové datum A přestat blokovat formulář.
+    const wrapper = mount(DateInput, { props: { modelValue: '2026-09-01' } })
+    const input = textField(wrapper)
+
+    await input.trigger('focus')
+    await input.setValue('31.2.2026')
+    await input.trigger('blur')
+    expect(input.element.validity.customError).toBe(true)
+
+    await wrapper.setProps({ modelValue: '2026-03-01' })
+    await nextTick()
+    expect(input.element.value).toBe('01. 03. 2026')
+    expect(input.element.validity.customError).toBe(false)
+    expect(input.attributes('aria-invalid')).toBeUndefined()
+  })
+
+  it('nativní kalendář zapíše vybrané datum do textu i modelu a vrátí fokus textu', async () => {
+    const wrapper = mount(DateInput, { props: { modelValue: '' }, attachTo: document.body })
+    const native = nativeField(wrapper)
+    native.element.focus()
+    native.element.value = '2026-03-08'
+    await native.trigger('change')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['2026-03-08']])
+    expect(textField(wrapper).element.value).toBe('08. 03. 2026')
+    // Safari zavře popover kalendáře až ztrátou fokusu nativního inputu.
+    expect(document.activeElement).toBe(textField(wrapper).element)
+    expect(native.attributes('tabindex')).toBe('-1')
+    expect(native.attributes('aria-hidden')).toBeUndefined()
+    expect(native.attributes('aria-label')).toBe('common.date_input.open_calendar')
+    wrapper.unmount()
+  })
+
+  it('„Vymazat" v nativním kalendáři vyprázdní pole i model (kontrakt 1:1)', async () => {
+    const wrapper = mount(DateInput, { props: { modelValue: '2026-09-01' } })
+    const native = nativeField(wrapper)
+    native.element.value = ''
+    await native.trigger('change')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['']])
+    expect(textField(wrapper).element.value).toBe('')
+  })
+
+  it('tlačítko kalendáře nejdřív fokusuje nativní pole a pak volá showPicker', async () => {
+    const wrapper = mount(DateInput, { props: { modelValue: '' }, attachTo: document.body })
+    const native = nativeField(wrapper).element as HTMLInputElement & { showPicker?: () => void }
+    const calls: string[] = []
+    native.showPicker = vi.fn(() => {
+      calls.push(document.activeElement === native ? 'showPicker-with-focus' : 'showPicker-without-focus')
+    })
+
+    await wrapper.get('button').trigger('click')
+    expect(calls).toEqual(['showPicker-with-focus'])
+    expect(wrapper.get('button').attributes('aria-label')).toBe('common.date_input.open_calendar')
+    wrapper.unmount()
+  })
+
+  it('psaní do neviditelného nativního pole (po zavření kalendáře bez výběru) přesměruje do textu i se znakem', async () => {
+    const wrapper = mount(DateInput, { props: { modelValue: '' }, attachTo: document.body })
+    const native = nativeField(wrapper)
+    native.element.focus()
+
+    await native.trigger('keydown', { key: '1' })
+    expect(document.activeElement).toBe(textField(wrapper).element)
+    expect(textField(wrapper).element.value).toBe('1')
+
+    // Tab se nepřesměrovává — má kam jít.
+    native.element.focus()
+    const tab = new KeyboardEvent('keydown', { key: 'Tab', cancelable: true })
+    native.element.dispatchEvent(tab)
+    expect(tab.defaultPrevented).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('předá required, třídy a data-atributy textovému poli; w-full roztáhne i obal', () => {
+    const wrapper = mount(DateInput, {
+      props: { modelValue: '', required: true },
+      attrs: { class: 'w-full h-10 px-3 border', 'data-row-input': 'inv-wr', name: 'issue_date', title: 'Od' },
+    })
+    const input = textField(wrapper)
+    expect(input.attributes('required')).toBeDefined()
+    expect(input.attributes('data-row-input')).toBe('inv-wr')
+    expect(input.attributes('name')).toBe('issue_date')
+    expect(input.attributes('title')).toBe('Od')
+    expect(input.classes()).toEqual(expect.arrayContaining(['w-full', 'h-10', 'px-3', 'border']))
+    expect(wrapper.element.className).toContain('w-full')
+  })
+
+  it('disabled zamkne text, kalendář i tlačítko', () => {
+    const wrapper = mount(DateInput, { props: { modelValue: '2026-09-01', disabled: true } })
+    expect(textField(wrapper).attributes('disabled')).toBeDefined()
+    expect(nativeField(wrapper).attributes('disabled')).toBeDefined()
+    expect(wrapper.get('button').attributes('disabled')).toBeDefined()
+  })
+
+  it('min/max: zápis mimo rozsah je neplatný s hláškou o rozsahu, ne o formátu', async () => {
+    const wrapper = mount(DateInput, { props: { modelValue: '', min: '2026-01-01', max: '2026-12-31' } })
+    const input = textField(wrapper)
+
+    await input.setValue('1.1.2025')
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    expect(input.attributes('aria-invalid')).toBe('true')
+    expect(input.element.validationMessage).toBe('common.date_input.out_of_range_between')
+
+    await input.setValue('1.6.2026')
+    expect(wrapper.emitted('update:modelValue')).toEqual([['2026-06-01']])
+    expect(input.attributes('aria-invalid')).toBeUndefined()
+    expect(input.element.validity.customError).toBe(false)
+
+    await wrapper.setProps({ min: undefined })
+    await input.setValue('1.1.2027')
+    expect(input.element.validationMessage).toBe('common.date_input.out_of_range_max')
+  })
+})
+
+describe('DateInput ve formuláři', () => {
+  it('neplatný zápis zablokuje odeslání formuláře, oprava ho zase pustí', async () => {
+    const wrapper = mount({
+      components: { DateInput },
+      template: '<form @submit.prevent><DateInput v-model="value" required /><button type="submit">Uložit</button></form>',
+      data: () => ({ value: '2026-09-01' }),
+    }, { attachTo: document.body })
+    const form = wrapper.get('form').element as HTMLFormElement
+    const input = textField(wrapper)
+
+    await input.trigger('focus')
+    await input.setValue('31.2.2026')
+    await input.trigger('blur')
+    expect(form.checkValidity()).toBe(false)
+    // Model drží poslední platnou hodnotu — nesmí se tedy uložit s ní, když pole říká něco jiného.
+    expect((wrapper.vm as unknown as { value: string }).value).toBe('2026-09-01')
+
+    await input.trigger('focus')
+    await input.setValue('28.2.2026')
+    await input.trigger('blur')
+    expect(form.checkValidity()).toBe(true)
+    expect((wrapper.vm as unknown as { value: string }).value).toBe('2026-02-28')
+
+    await input.setValue('')
+    expect(form.checkValidity()).toBe(false) // required
+    wrapper.unmount()
+  })
+
+  it('bez showPicker spadne na focus+click nativního pole', async () => {
+    const wrapper = mount(DateInput, { props: { modelValue: '' } })
+    const native = nativeField(wrapper).element
+    // jsdom showPicker nemá; explicitně ho odstraníme, ať test nezávisí na verzi jsdom.
+    Object.defineProperty(native, 'showPicker', { value: undefined, configurable: true })
+    const focus = vi.spyOn(native, 'focus')
+    const click = vi.spyOn(native, 'click')
+
+    await wrapper.get('button').trigger('click')
+    expect(focus).toHaveBeenCalledTimes(1)
+    expect(click).toHaveBeenCalledTimes(1)
+  })
+
+  it('kopie, která přestane být vykreslená (responzivní duplikát), zahodí rozepsanou chybu a přestane blokovat formulář', async () => {
+    type RoCallback = (entries: Array<{ contentRect: { width: number; height: number } }>) => void
+    let callback: RoCallback | null = null
+    const observe = vi.fn()
+    const disconnect = vi.fn()
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(cb: RoCallback) { callback = cb }
+      observe = observe
+      disconnect = disconnect
+    })
+    try {
+      const wrapper = mount(DateInput, { props: { modelValue: '2026-09-01' } })
+      const input = textField(wrapper)
+      expect(observe).toHaveBeenCalledWith(input.element)
+
+      await input.trigger('focus')
+      await input.setValue('31.2.2026')
+      await input.trigger('blur')
+      expect(input.element.validity.customError).toBe(true)
+
+      callback!([{ contentRect: { width: 0, height: 0 } }])
+      await nextTick()
+      await nextTick()
+      expect(input.element.value).toBe('01. 09. 2026')
+      expect(input.element.validity.customError).toBe(false)
+
+      wrapper.unmount()
+      expect(disconnect).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/web/src/components/ui/DateInput.vue
+++ b/web/src/components/ui/DateInput.vue
@@ -1,0 +1,313 @@
+<script setup lang="ts">
+/**
+ * Datumové pole, které mluví jazykem aplikace.
+ *
+ * Why: nativní `<input type="date">` formátuje podle jazyka prohlížeče, ne
+ * aplikace (myinvoice#276). Uživatel s anglickým systémem a českým rozhraním tak
+ * vedle „01. 09. 2026" ve výpisu edituje „09/01/2026" a u prvních dvanácti dnů
+ * měsíce prohozený měsíc nepozná. Textové pole tady píše i čte v pořadí složek
+ * jazyka aplikace (viz utils/dateInput.ts), nativní kalendář zůstává za ikonou.
+ *
+ * Kontrakt `v-model` je shodný s nativním inputem — ISO `YYYY-MM-DD` nebo `''` —
+ * takže je to náhrada 1:1 bez zásahu do dat, watcherů ani API.
+ */
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useAttrs, useId, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { formatIsoForInput, parseInputDate } from '@/utils/dateInput'
+import { ICONS } from './buttonStyles'
+
+defineOptions({ inheritAttrs: false })
+
+const props = withDefaults(defineProps<{
+  modelValue: string | null | undefined
+  required?: boolean
+  disabled?: boolean
+  readonly?: boolean
+  /** ISO hranice pro nativní kalendář; textový zápis mimo rozsah označí pole neplatné. */
+  min?: string
+  max?: string
+  invalid?: boolean
+  accent?: 'primary' | 'payroll'
+  inputId?: string
+  ariaLabel?: string
+}>(), {
+  required: false,
+  disabled: false,
+  readonly: false,
+  min: undefined,
+  max: undefined,
+  invalid: false,
+  accent: 'primary',
+  inputId: undefined,
+  ariaLabel: undefined,
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+  'blur': [event: FocusEvent]
+}>()
+
+const attrs = useAttrs()
+const { t, locale } = useI18n()
+
+const textInput = ref<HTMLInputElement | null>(null)
+const nativeInput = ref<HTMLInputElement | null>(null)
+const text = ref(formatIsoForInput(props.modelValue, locale.value))
+const focused = ref(false)
+/**
+ * Text neodpovídá žádnému platnému datu (`unparsable`), nebo je to platné datum
+ * mimo min/max (`outOfRange`). Obojí drží formulář neodeslatelný; vizuálně se
+ * ukáže až po opuštění pole, aby rozepsaný zápis neblikal červeně.
+ */
+const unparsable = ref(false)
+const outOfRange = ref(false)
+const generatedId = `date-input-${useId()}`
+
+const id = computed(() => props.inputId ?? (attrs.id as string | undefined) ?? generatedId)
+const hasError = computed(() => unparsable.value || outOfRange.value)
+const isInvalid = computed(() => props.invalid || (hasError.value && !focused.value))
+const inactive = computed(() => props.disabled || props.readonly)
+
+/** Třídy z místa použití patří na textové pole (velikost, rámeček); wrapper jen drží ikonu. */
+const passedClass = computed(() => (attrs.class as string | undefined) ?? '')
+const wrapperClass = computed(() => /\bw-full\b/.test(passedClass.value) ? 'relative block w-full' : 'relative inline-block')
+const accentClass = computed(() => props.accent === 'payroll'
+  ? 'focus:ring-payroll-500/20 focus:border-payroll-500'
+  : 'focus:ring-primary-500/20 focus:border-primary-500')
+
+/** Vše kromě class/id jde na textové pole (data-* atributy, name, title, aria-*, style). */
+const forwardedAttrs = computed(() => {
+  const rest: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(attrs)) {
+    if (key === 'class' || key === 'id') continue
+    rest[key] = value
+  }
+  return rest
+})
+
+function withinBounds(iso: string): boolean {
+  if (props.min && iso < props.min) return false
+  if (props.max && iso > props.max) return false
+  return true
+}
+
+function rangeMessage(): string {
+  const min = props.min ? formatIsoForInput(props.min, locale.value) : ''
+  const max = props.max ? formatIsoForInput(props.max, locale.value) : ''
+  if (min && max) return t('common.date_input.out_of_range_between', { min, max })
+  if (min) return t('common.date_input.out_of_range_min', { min })
+  return t('common.date_input.out_of_range_max', { max })
+}
+
+function syncValidity(): void {
+  // Nativní validita formuláře: `required` hlídá prohlížeč sám, nesmyslný zápis
+  // a datum mimo rozsah hlásíme přes setCustomValidity, aby form.checkValidity()
+  // (a tím i Enter / Ctrl+S přes requestSubmit) zůstalo pravdivé.
+  const message = unparsable.value
+    ? t('common.date_input.invalid')
+    : outOfRange.value ? rangeMessage() : ''
+  textInput.value?.setCustomValidity(message)
+}
+
+function clearErrors(): void {
+  unparsable.value = false
+  outOfRange.value = false
+}
+
+function commit(iso: string): void {
+  clearErrors()
+  syncValidity()
+  if (iso !== (props.modelValue ?? '')) emit('update:modelValue', iso)
+}
+
+/**
+ * Vyhodnotí text: platný a v rozsahu → commit a vrátí ISO ('' pro prázdné);
+ * jinak nastaví příznak chyby a vrátí null.
+ */
+function applyText(value: string, { allowShortYear }: { allowShortYear: boolean }): string | null {
+  if (value.trim() === '') {
+    commit('')
+    return ''
+  }
+  const iso = parseInputDate(value, locale.value, { allowShortYear })
+  if (iso === null) {
+    unparsable.value = true
+    outOfRange.value = false
+  } else if (!withinBounds(iso)) {
+    unparsable.value = false
+    outOfRange.value = true
+  } else {
+    // Platné už během psaní: watchery (splatnost z data vystavení) reagují hned,
+    // stejně jako u nativního inputu. Text se kanonizuje až na blur, ať kurzor neskáče.
+    commit(iso)
+    return iso
+  }
+  syncValidity()
+  return null
+}
+
+function onInput(event: Event): void {
+  text.value = (event.target as HTMLInputElement).value
+  // Dvouciferný rok se během psaní nepřijímá: „1.9.20" je mezistav k „1.9.2026",
+  // a jako rok 2020 by rozjel přepočet splatnosti i asynchronní dotazy (číselná
+  // řada, ceník) nad datem, které uživatel nikdy nemyslel. Doplní se až na blur.
+  applyText(text.value, { allowShortYear: false })
+}
+
+function onBlur(event: FocusEvent): void {
+  focused.value = false
+  // Kanonizovat z právě potvrzeného ISO, ne z props.modelValue — rodič ho po
+  // emitu přepíše až v dalším ticku.
+  const iso = applyText(text.value, { allowShortYear: true })
+  if (iso !== null) text.value = formatIsoForInput(iso, locale.value)
+  emit('blur', event)
+}
+
+function onNativeChange(event: Event): void {
+  const iso = (event.target as HTMLInputElement).value
+  // Prázdná hodnota = tlačítko „Vymazat" v kalendáři (Firefox). Nativní input
+  // by emitoval '', tak i my — kontrakt 1:1.
+  commit(iso)
+  text.value = formatIsoForInput(iso, locale.value)
+  // Fokus zpět textovému poli: nativní input tím ztratí fokus a Safari zavře
+  // popover kalendáře (Chrome ho po výběru zavírá sám). Uživatel navíc může
+  // rovnou pokračovat psaním nebo Tabem na další pole.
+  textInput.value?.focus({ preventScroll: true })
+}
+
+/**
+ * Kalendář zavřený bez výběru (Escape, klik mimo) nechá fokus na neviditelném
+ * nativním inputu — uživatel to nevidí a jeho psaní by tiše editovalo skryté
+ * segmenty data. Klávesová událost při otevřeném popoveru k inputu nedorazí,
+ * ale první stisk po zavření ano: přesměrujeme ho do textového pole a znak
+ * nezahodíme. Tab nechat být — má kam jít.
+ */
+function onNativeKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Tab') return
+  event.preventDefault()
+  const field = textInput.value
+  if (!field) return
+  field.focus({ preventScroll: true })
+  if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+    text.value = text.value + event.key
+    applyText(text.value, { allowShortYear: false })
+  }
+}
+
+function openPicker(): void {
+  const el = nativeInput.value
+  if (!el || inactive.value) return
+  // Safari drží popover kalendáře jen dokud má nativní input fokus — bez něj
+  // zůstane viset, kliknutí do stránky ho nezavřou a dál mění TOTO pole.
+  // Proto nejdřív fokus, teprve pak showPicker.
+  el.focus({ preventScroll: true })
+  try {
+    if (typeof el.showPicker === 'function') {
+      el.showPicker()
+      return
+    }
+  } catch {
+    // showPicker vyžaduje uživatelské gesto a bezpečný kontext; když odmítne,
+    // spadneme na click, který v prohlížečích bez showPicker kalendář otevře taky.
+  }
+  el.click()
+}
+
+function resetToModel(): void {
+  text.value = formatIsoForInput(props.modelValue, locale.value)
+  clearErrors()
+  void nextTick(syncValidity)
+}
+
+// Změna zvenčí (načtení faktury, přepočet splatnosti, přepnutí jazyka) přepíše
+// text. Výjimka jen pro pole, ve kterém uživatel právě píše:
+//  - rozepsaný (neplatný) text se nezahodí,
+//  - hotový zápis, který už modelu odpovídá („1.9.2026" → 2026-09-01), se
+//    nepřeformátuje pod kurzorem — kanonizuje ho až blur.
+// Fokus sám důvodem není: splatnost přepočtená z data vystavení se musí
+// ukázat i v poli, které má zrovna fokus, jinak by ji blur přepsal starou hodnotou.
+watch(() => [props.modelValue, locale.value] as const, ([iso]) => {
+  if (focused.value) {
+    if (hasError.value) return
+    if (parseInputDate(text.value, locale.value) === (iso || null)) return
+  }
+  resetToModel()
+})
+
+// Responzivní editory renderují totéž pole dvakrát (tabulka `hidden md:block`
+// a karty `md:hidden`) a display:none instanci neodpojí. Rozepsaná chyba v kopii,
+// kterou uživatel po změně šířky okna už nevidí, by přes setCustomValidity dál
+// blokovala odeslání formuláře bez jakéhokoli viditelného důvodu. Proto se
+// instance, která přestane být vykreslená, vrátí k hodnotě modelu.
+let resizeObserver: ResizeObserver | null = null
+onMounted(() => {
+  if (typeof ResizeObserver === 'undefined' || !textInput.value) return
+  resizeObserver = new ResizeObserver((entries) => {
+    const box = entries[0]?.contentRect
+    if (box && box.width === 0 && box.height === 0 && hasError.value) resetToModel()
+  })
+  resizeObserver.observe(textInput.value)
+})
+onBeforeUnmount(() => resizeObserver?.disconnect())
+</script>
+
+<template>
+  <div :class="wrapperClass">
+    <input
+      ref="textInput"
+      v-bind="forwardedAttrs"
+      :id="id"
+      type="text"
+      inputmode="numeric"
+      autocomplete="off"
+      :value="text"
+      :placeholder="t('common.date_input.placeholder')"
+      :required="required"
+      :disabled="disabled"
+      :readonly="readonly"
+      :aria-label="ariaLabel"
+      :aria-invalid="isInvalid || undefined"
+      :class="[
+        passedClass,
+        'pr-9 bg-surface text-neutral-900 placeholder:text-neutral-500',
+        `focus:ring-2 outline-none ${accentClass}`,
+        'disabled:bg-neutral-50 disabled:text-neutral-400 disabled:cursor-not-allowed',
+        isInvalid ? 'border-danger-500' : '',
+      ]"
+      @focus="focused = true"
+      @input="onInput"
+      @blur="onBlur"
+    >
+    <!--
+      Nativní kalendář: skrytý date input leží přesně pod ikonou, aby prohlížeč
+      ukotvil vyskakovací kalendář k ní. Ovládá se jen ikonou (tabindex -1),
+      klávesnice patří textovému poli. Není aria-hidden — při otevřeném
+      kalendáři fokus drží (Safari), a fokusovaný aria-hidden prvek je chyba.
+    -->
+    <input
+      ref="nativeInput"
+      type="date"
+      tabindex="-1"
+      :aria-label="t('common.date_input.open_calendar')"
+      :value="modelValue ?? ''"
+      :min="min"
+      :max="max"
+      :disabled="inactive"
+      class="absolute inset-y-0 right-0 w-8 opacity-0 pointer-events-none"
+      @change="onNativeChange"
+      @keydown="onNativeKeydown"
+    >
+    <button
+      type="button"
+      :disabled="inactive"
+      :aria-label="t('common.date_input.open_calendar')"
+      :title="t('common.date_input.open_calendar')"
+      class="absolute inset-y-0 right-0 flex w-8 items-center justify-center rounded-r-md text-neutral-500 transition-colors hover:text-neutral-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40 disabled:cursor-not-allowed disabled:opacity-50"
+      @click="openPicker"
+    >
+      <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+        <path :d="ICONS.calendar" />
+      </svg>
+    </button>
+  </div>
+</template>

--- a/web/src/i18n/cs.json
+++ b/web/src/i18n/cs.json
@@ -13267,7 +13267,15 @@
       "říjen",
       "listopad",
       "prosinec"
-    ]
+    ],
+    "date_input": {
+      "placeholder": "d. m. rrrr",
+      "invalid": "Zadejte platné datum ve tvaru d. m. rrrr.",
+      "open_calendar": "Otevřít kalendář",
+      "out_of_range_between": "Datum musí být mezi {min} a {max}.",
+      "out_of_range_min": "Datum nesmí být před {min}.",
+      "out_of_range_max": "Datum nesmí být po {max}."
+    }
   },
   "codebookTransfer": {
     "export": "Export XLSX",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -13267,7 +13267,15 @@
       "October",
       "November",
       "December"
-    ]
+    ],
+    "date_input": {
+      "placeholder": "mm/dd/yyyy",
+      "invalid": "Enter a valid date as mm/dd/yyyy.",
+      "open_calendar": "Open calendar",
+      "out_of_range_between": "The date must be between {min} and {max}.",
+      "out_of_range_min": "The date must not be before {min}.",
+      "out_of_range_max": "The date must not be after {max}."
+    }
   },
   "codebookTransfer": {
     "export": "Export XLSX",

--- a/web/src/pages/invoices/InvoiceEditor.vue
+++ b/web/src/pages/invoices/InvoiceEditor.vue
@@ -12,10 +12,15 @@ import { useI18n } from 'vue-i18n'
 const { t, locale } = useI18n()
 const toast = useToast()
 const pageId = useId()
+const editorForm = ref<HTMLFormElement | null>(null)
 const paneDom = usePaneDom()
 const { blockDemoMutation } = useDemoMode()
 
-useHotkey('ctrl+s', (e) => { e.preventDefault(); submit() })
+// requestSubmit() místo submit(): projde nativní validací formuláře (required,
+// DateInput.setCustomValidity) stejně jako klik na Uložit — přímé volání by
+// s rozepsaným neplatným datem tiše uložilo poslední platnou hodnotu. Bez
+// formuláře (ještě se načítá) zkratka nedělá nic — žádný obcházející fallback.
+useHotkey('ctrl+s', (e) => { e.preventDefault(); editorForm.value?.requestSubmit() })
 import { clientsApi, type Client, type ViesLookupResult } from '@/api/clients'
 import { projectsApi, type Project } from '@/api/projects'
 import { codebooksApi, type VatRate, type Currency, type Unit } from '@/api/codebooks'
@@ -28,6 +33,7 @@ import { useSupplierStore } from '@/stores/supplier'
 import { useAuthStore } from '@/stores/auth'
 import SearchableSelect from '@/components/ui/SearchableSelect.vue'
 import CountrySelect from '@/components/ui/CountrySelect.vue'
+import DateInput from '@/components/ui/DateInput.vue'
 import StockDescriptionField from '@/components/ui/StockDescriptionField.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
 import ClientFormModal from '@/components/modals/ClientFormModal.vue'
@@ -1680,6 +1686,10 @@ function userChangedExchangeRate(): boolean {
 
 async function submit() {
   if (blockDemoMutation()) return
+  // Tlačítko Uložit je při odesílání disabled, ale requestSubmit() z Ctrl+S
+  // submit event vyvolá i tak — bez této pojistky by druhý stisk během
+  // rozběhnutého requestu založil doklad dvakrát (stejně jako v editoru přijatých).
+  if (submitting.value) return
   // Tiše vyhoď prázdné řádky (bez popisu i bez ceny) — uživatel přidal řádek a nezapsal ho.
   // Zároveň smaž z form.value.items, ať checkWorkReportSync vidí stejnou množinu jako payload.
   form.value.items = form.value.items.filter(it =>
@@ -1933,7 +1943,7 @@ async function deleteDraft() {
       </div>
     </div>
 
-    <form @submit.prevent="submit" class="space-y-4">
+    <form ref="editorForm" @submit.prevent="submit" class="space-y-4">
       <!-- Klient + zakázka + datumy -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div class="bg-surface border border-neutral-200 rounded-lg p-5 shadow-sm">
@@ -2160,18 +2170,18 @@ async function deleteDraft() {
             </div>
             <div>
               <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('invoice.issue_date') }} *</label>
-              <input v-model="form.issue_date" type="date" required class="w-full h-10 px-3 border border-neutral-300 rounded-md" />
+              <DateInput v-model="form.issue_date" required class="w-full h-10 px-3 border border-neutral-300 rounded-md" />
             </div>
             <div v-if="form.invoice_type !== 'proforma'">
               <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('invoice.tax_date') }} *</label>
-              <input v-model="form.tax_date" type="date" required class="w-full h-10 px-3 border border-neutral-300 rounded-md" />
+              <DateInput v-model="form.tax_date" required class="w-full h-10 px-3 border border-neutral-300 rounded-md" />
             </div>
             <div v-else class="rounded-md bg-accent-50 border border-accent-100 p-3 text-sm text-accent-600">
               {{ t('invoice.proforma_no_tax_point') }}
             </div>
             <div>
               <label class="block text-sm font-medium text-neutral-700 mb-1">{{ t('invoice.due_date') }} *</label>
-              <input v-model="form.due_date" type="date" required class="w-full h-10 px-3 border border-neutral-300 rounded-md" />
+              <DateInput v-model="form.due_date" required class="w-full h-10 px-3 border border-neutral-300 rounded-md" />
             </div>
             <div v-if="form.invoice_type !== 'credit_note' && remindersAvailable">
               <label class="flex items-center gap-2 text-sm text-neutral-700">
@@ -2671,7 +2681,7 @@ async function deleteDraft() {
               <tbody>
                 <tr v-for="(row, i) in form.payment_schedule" :key="i" class="border-t border-neutral-200">
                   <td class="py-2 pr-3">
-                    <input v-model="row.due_on" type="date" class="h-9 px-2 border border-neutral-300 rounded-md bg-surface" />
+                    <DateInput v-model="row.due_on" class="w-36 h-9 px-2 border border-neutral-300 rounded-md bg-surface" />
                   </td>
                   <td class="py-2 pr-3">
                     <input v-model.number="row.base_amount" type="number" step="0.01"
@@ -2774,7 +2784,7 @@ async function deleteDraft() {
                   <input v-model="it.description" type="text" data-row-input="inv-wr" class="w-full h-9 px-2 border border-neutral-300 rounded text-sm" />
                 </td>
                 <td class="px-2 py-1.5">
-                  <input v-model="it.work_date" type="date" class="w-full h-9 px-2 border border-neutral-300 rounded text-sm font-mono" />
+                  <DateInput v-model="it.work_date" class="w-full h-9 px-2 border border-neutral-300 rounded text-sm font-mono" />
                 </td>
                 <td class="px-2 py-1.5">
                   <input v-model.number="it.hours" type="number" step="0.25" min="0" class="w-full h-9 px-2 border border-neutral-300 rounded text-sm text-right font-mono" />
@@ -2841,7 +2851,7 @@ async function deleteDraft() {
               <div class="grid grid-cols-2 gap-2">
                 <div>
                   <label class="block text-xs font-medium text-neutral-600 mb-1">{{ t('invoice.wr_date') }}</label>
-                  <input v-model="it.work_date" type="date" class="w-full h-10 px-3 border border-neutral-300 rounded text-sm font-mono bg-surface" />
+                  <DateInput v-model="it.work_date" class="w-full h-10 px-3 border border-neutral-300 rounded text-sm font-mono bg-surface" />
                 </div>
                 <div>
                   <label class="block text-xs font-medium text-neutral-600 mb-1">{{ t('invoice.wr_hours') }}</label>

--- a/web/src/pages/purchase-invoices/InvoiceEditor.vue
+++ b/web/src/pages/purchase-invoices/InvoiceEditor.vue
@@ -42,6 +42,7 @@ import { useToast } from '@/composables/useToast'
 import { useDemoMode } from '@/composables/useDemoMode'
 import { apiErrorMessage } from '@/api/errors'
 import StockDescriptionField from '@/components/ui/StockDescriptionField.vue'
+import DateInput from '@/components/ui/DateInput.vue'
 import ExpenseKindSuggestionHint from '@/components/purchase/ExpenseKindSuggestionHint.vue'
 import VendorPicker from '@/components/purchase/VendorPicker.vue'
 import ClientFormModal from '@/components/modals/ClientFormModal.vue'
@@ -1739,19 +1740,19 @@ function fieldErr(key: string): string | null {
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
           <div>
             <label class="block text-sm text-neutral-700 mb-1">{{ t('purchase_invoice.fields.issue_date') }} <span class="text-danger-500">*</span></label>
-            <input v-model="form.issue_date" type="date" required class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm" />
+            <DateInput v-model="form.issue_date" required class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm" />
           </div>
           <div>
             <label class="block text-sm text-neutral-700 mb-1">{{ t('purchase_invoice.fields.tax_date') }}</label>
-            <input v-model="form.tax_date" type="date" class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm" />
+            <DateInput v-model="form.tax_date" class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm" />
           </div>
           <div>
             <label class="block text-sm text-neutral-700 mb-1">{{ t('purchase_invoice.fields.due_date') }} <span class="text-danger-500">*</span></label>
-            <input v-model="form.due_date" type="date" required class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm" />
+            <DateInput v-model="form.due_date" required class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm" />
           </div>
           <div>
             <label class="block text-sm text-neutral-700 mb-1">{{ t('purchase_invoice.fields.received_at') }}</label>
-            <input v-model="form.received_at" type="date" class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm" />
+            <DateInput v-model="form.received_at" class="w-full h-10 px-3 border border-neutral-300 rounded-md text-sm" />
           </div>
         </div>
         <!-- RC: DPH období se řídí DUZP (§ 25 / § 24), ne datem vystavení — issue #117 -->
@@ -1928,9 +1929,9 @@ function fieldErr(key: string): string | null {
                     {{ accrualVisible(it, i) ? t('purchase_invoice.items.accrual_remove') : t('purchase_invoice.items.accrual_add') }}
                   </button>
                   <div v-if="accrualVisible(it, i)" class="mt-1 space-y-1">
-                    <input v-model="it.accrual_from" type="date" :title="t('purchase_invoice.items.accrual_from')"
+                    <DateInput v-model="it.accrual_from" :title="t('purchase_invoice.items.accrual_from')"
                       class="w-full h-8 px-1 border border-neutral-300 rounded bg-surface text-xs" />
-                    <input v-model="it.accrual_to" type="date" :title="t('purchase_invoice.items.accrual_to')"
+                    <DateInput v-model="it.accrual_to" :title="t('purchase_invoice.items.accrual_to')"
                       class="w-full h-8 px-1 border border-neutral-300 rounded bg-surface text-xs" />
                   </div>
                 </template>
@@ -2026,11 +2027,11 @@ function fieldErr(key: string): string | null {
                 <div v-if="accrualVisible(it, i)" class="mt-1 grid grid-cols-2 gap-2">
                   <div>
                     <label class="block text-xs text-neutral-600 mb-1">{{ t('purchase_invoice.items.accrual_from') }}</label>
-                    <input v-model="it.accrual_from" type="date" class="w-full h-10 px-2 border border-neutral-300 rounded bg-surface text-sm" />
+                    <DateInput v-model="it.accrual_from" class="w-full h-10 px-2 border border-neutral-300 rounded bg-surface text-sm" />
                   </div>
                   <div>
                     <label class="block text-xs text-neutral-600 mb-1">{{ t('purchase_invoice.items.accrual_to') }}</label>
-                    <input v-model="it.accrual_to" type="date" class="w-full h-10 px-2 border border-neutral-300 rounded bg-surface text-sm" />
+                    <DateInput v-model="it.accrual_to" class="w-full h-10 px-2 border border-neutral-300 rounded bg-surface text-sm" />
                   </div>
                 </div>
               </template>

--- a/web/src/utils/__tests__/dateInput.spec.ts
+++ b/web/src/utils/__tests__/dateInput.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { dateInputLocale, formatIsoForInput, isoParts, parseInputDate } from '@/utils/dateInput'
+
+describe('dateInputLocale', () => {
+  it('čeština píše den-měsíc-rok s tečkou, angličtina měsíc-den-rok s lomítkem', () => {
+    expect(dateInputLocale('cs')).toEqual({ tag: 'cs-CZ', order: ['day', 'month', 'year'], separator: '.' })
+    expect(dateInputLocale('en')).toEqual({ tag: 'en-US', order: ['month', 'day', 'year'], separator: '/' })
+  })
+})
+
+describe('formatIsoForInput', () => {
+  it('formátuje podle jazyka aplikace, ne prohlížeče', () => {
+    expect(formatIsoForInput('2026-09-01', 'cs')).toBe('01. 09. 2026')
+    expect(formatIsoForInput('2026-09-01', 'en')).toBe('09/01/2026')
+  })
+
+  it('prázdné a neplatné hodnoty nechá pole prázdné', () => {
+    expect(formatIsoForInput('', 'cs')).toBe('')
+    expect(formatIsoForInput(null, 'cs')).toBe('')
+    expect(formatIsoForInput('2026-02-31', 'cs')).toBe('')
+    expect(formatIsoForInput('nesmysl', 'cs')).toBe('')
+  })
+})
+
+describe('parseInputDate', () => {
+  it('česky: tečky, mezery i zkrácený zápis', () => {
+    expect(parseInputDate('1.9.2026', 'cs')).toBe('2026-09-01')
+    expect(parseInputDate('01. 09. 2026', 'cs')).toBe('2026-09-01')
+    expect(parseInputDate('  1 . 9 . 2026 ', 'cs')).toBe('2026-09-01')
+    expect(parseInputDate('1.9.26', 'cs')).toBe('2026-09-01')
+    expect(parseInputDate('01092026', 'cs')).toBe('2026-09-01')
+    expect(parseInputDate('31.12.2026', 'cs')).toBe('2026-12-31')
+  })
+
+  it('anglicky: měsíc před dnem — přesně to, co issue #276 řeší', () => {
+    expect(parseInputDate('9/1/2026', 'en')).toBe('2026-09-01')
+    expect(parseInputDate('09/01/2026', 'en')).toBe('2026-09-01')
+    expect(parseInputDate('09012026', 'en')).toBe('2026-09-01')
+    // Stejný text má v každém jazyce jiný význam — proto je jazyk parametr.
+    expect(parseInputDate('9/1/2026', 'cs')).toBe('2026-01-09')
+  })
+
+  it('dvouciferný rok jde vypnout — během psaní je „1.9.20" mezistav, ne rok 2020', () => {
+    expect(parseInputDate('1.9.20', 'cs', { allowShortYear: false })).toBeNull()
+    expect(parseInputDate('1.9.2026', 'cs', { allowShortYear: false })).toBe('2026-09-01')
+    expect(parseInputDate('9/1/26', 'en')).toBe('2026-09-01')
+    expect(parseInputDate('9/1/26', 'en', { allowShortYear: false })).toBeNull()
+    expect(parseInputDate('1.9.203', 'cs')).toBeNull()
+    expect(parseInputDate('1.9.20326', 'cs')).toBeNull()
+  })
+
+  it('ISO projde v každém jazyce (schránka, API)', () => {
+    expect(parseInputDate('2026-09-01', 'cs')).toBe('2026-09-01')
+    expect(parseInputDate('2026-09-01', 'en')).toBe('2026-09-01')
+  })
+
+  it('neexistující datum odmítne místo tichého posunu', () => {
+    expect(parseInputDate('31.2.2026', 'cs')).toBeNull()
+    expect(parseInputDate('29.2.2025', 'cs')).toBeNull()
+    expect(parseInputDate('29.2.2024', 'cs')).toBe('2024-02-29')
+    expect(parseInputDate('0.9.2026', 'cs')).toBeNull()
+    expect(parseInputDate('1.13.2026', 'cs')).toBeNull()
+    expect(parseInputDate('2026-02-31', 'cs')).toBeNull()
+  })
+
+  it('rozepsaný nebo cizí vstup vrací null, ne částečné datum', () => {
+    expect(parseInputDate('', 'cs')).toBeNull()
+    expect(parseInputDate('1.9.', 'cs')).toBeNull()
+    expect(parseInputDate('1.9.202', 'cs')).toBeNull()
+    expect(parseInputDate('1.9.20266', 'cs')).toBeNull()
+    expect(parseInputDate('dnes', 'cs')).toBeNull()
+    expect(parseInputDate('1.9.2026.5', 'cs')).toBeNull()
+  })
+})
+
+describe('isoParts', () => {
+  it('rozloží jen platné ISO datum', () => {
+    expect(isoParts('2026-09-01')).toEqual({ year: 2026, month: 9, day: 1 })
+    expect(isoParts('2026-9-1')).toBeNull()
+    expect(isoParts('2026-02-30')).toBeNull()
+  })
+})

--- a/web/src/utils/dateInput.ts
+++ b/web/src/utils/dateInput.ts
@@ -1,0 +1,143 @@
+/**
+ * Převody mezi ISO datem (`YYYY-MM-DD`, tvar v datech i v API) a textem,
+ * jak ho píše a čte uživatel v jazyce aplikace.
+ *
+ * Why: nativní `<input type="date">` formátuje podle jazyka PROHLÍŽEČE, ne
+ * aplikace. Uživatel s anglickým systémem a českým rozhraním tak vidí vedle
+ * sebe „01. 09. 2026" (vypsané) a „09/01/2026" (editovatelné) a u prvních
+ * dvanácti dnů měsíce nepozná prohozený měsíc. Tady se formát odvozuje z Intl
+ * pro jazyk aplikace — stejně jako `formatDate()` v useFormat — a parser bere
+ * stejné pořadí složek, takže zápis i výpis mluví jedním jazykem.
+ *
+ * Čistě funkční modul bez závislosti na i18n instanci, aby se dal testovat
+ * bez mountování komponent.
+ */
+
+export type DatePart = 'day' | 'month' | 'year'
+
+export interface DateInputLocale {
+  /** BCP-47 tag pro Intl (`cs-CZ`, `en-US`). */
+  tag: string
+  /** Pořadí složek, jak ho jazyk píše (cs: den-měsíc-rok, en-US: měsíc-den-rok). */
+  order: DatePart[]
+  /** Oddělovač složek bez okolních mezer (`.` nebo `/`). */
+  separator: string
+}
+
+const ISO_RE = /^(\d{4})-(\d{2})-(\d{2})$/
+
+/** Stejné mapování jazyka aplikace na Intl tag jako v useFormat.ts. */
+export function localeTag(appLocale: string): string {
+  return appLocale === 'en' ? 'en-US' : 'cs-CZ'
+}
+
+const localeCache = new Map<string, DateInputLocale>()
+
+/** Pořadí složek a oddělovač jazyka, odvozené z Intl (ne ručně psaná tabulka). */
+export function dateInputLocale(appLocale: string): DateInputLocale {
+  const tag = localeTag(appLocale)
+  const cached = localeCache.get(tag)
+  if (cached) return cached
+
+  const parts = new Intl.DateTimeFormat(tag, { day: '2-digit', month: '2-digit', year: 'numeric' })
+    .formatToParts(new Date(2001, 11, 31))
+  const order = parts
+    .map(part => part.type)
+    .filter((type): type is DatePart => type === 'day' || type === 'month' || type === 'year')
+  const literal = parts.find(part => part.type === 'literal')?.value.trim() ?? '.'
+  const resolved: DateInputLocale = {
+    tag,
+    order: order.length === 3 ? order : ['day', 'month', 'year'],
+    separator: literal === '' ? '.' : literal,
+  }
+  localeCache.set(tag, resolved)
+  return resolved
+}
+
+/** Rozloží platné ISO datum na čísla; `null` pro cokoli jiného (včetně 31. 2.). */
+export function isoParts(iso: string): { year: number; month: number; day: number } | null {
+  const match = ISO_RE.exec(iso)
+  if (!match) return null
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  return isRealDate(year, month, day) ? { year, month, day } : null
+}
+
+function isRealDate(year: number, month: number, day: number): boolean {
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return false
+  if (year < 1000 || year > 9999 || month < 1 || month > 12 || day < 1) return false
+  return day <= new Date(year, month, 0).getDate()
+}
+
+function toIso(year: number, month: number, day: number): string {
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+}
+
+/**
+ * ISO → text v jazyce aplikace (`2026-09-01` → „01. 09. 2026" / „09/01/2026").
+ * Neplatný nebo prázdný vstup vrací prázdný řetězec — pole se nemá tvářit vyplněné.
+ */
+export function formatIsoForInput(iso: string | null | undefined, appLocale: string): string {
+  if (!iso) return ''
+  const parts = isoParts(iso)
+  if (!parts) return ''
+  return new Intl.DateTimeFormat(localeTag(appLocale), { day: '2-digit', month: '2-digit', year: 'numeric' })
+    .format(new Date(parts.year, parts.month - 1, parts.day))
+}
+
+/**
+ * Text od uživatele → ISO, nebo `null`, když to (ještě) není platné datum.
+ *
+ * Přijímá:
+ *  - složky v pořadí jazyka oddělené `.`, `/`, `-` nebo mezerou, s libovolnými
+ *    mezerami okolo (`1.9.2026`, `01. 09. 2026`, `9/1/2026`),
+ *  - dvouciferný rok jako 20xx (`1.9.26`) — jen s `allowShortYear` (default);
+ *    během psaní ho volající vypne, protože „1.9.20" je jen mezistav cesty
+ *    k „1.9.2026" a jako rok 2020 by spustil přepočty nad špatným datem,
+ *  - souvislých 8 číslic v pořadí jazyka (`01092026`),
+ *  - ISO `YYYY-MM-DD` v každém jazyce (co přijde ze schránky nebo z API).
+ * Odmítá neexistující dny (`31. 2.`) — vrátit posunuté datum by bylo horší než nic.
+ */
+export function parseInputDate(
+  text: string,
+  appLocale: string,
+  { allowShortYear = true }: { allowShortYear?: boolean } = {},
+): string | null {
+  const raw = text.trim()
+  if (raw === '') return null
+
+  const iso = ISO_RE.exec(raw)
+  if (iso) return isoParts(raw) ? raw : null
+
+  const { order } = dateInputLocale(appLocale)
+  let tokens: string[]
+  if (/^\d{8}$/.test(raw)) {
+    tokens = []
+    let cursor = 0
+    for (const part of order) {
+      const width = part === 'year' ? 4 : 2
+      tokens.push(raw.slice(cursor, cursor + width))
+      cursor += width
+    }
+  } else {
+    tokens = raw.split(/\s*[./\-\s]\s*/).filter(token => token !== '')
+  }
+  if (tokens.length !== 3 || tokens.some(token => !/^\d{1,4}$/.test(token))) return null
+
+  const values: Record<DatePart, number> = { day: 0, month: 0, year: 0 }
+  order.forEach((part, index) => {
+    values[part] = Number(tokens[index])
+  })
+  const yearToken = tokens[order.indexOf('year')]
+  if (yearToken.length === 2) {
+    if (!allowShortYear) return null
+    values.year += 2000
+  } else if (yearToken.length !== 4) {
+    return null
+  }
+
+  return isRealDate(values.year, values.month, values.day)
+    ? toIso(values.year, values.month, values.day)
+    : null
+}


### PR DESCRIPTION
Řeší radekhulan/myinvoice#276 (založeno omylem tam, kód je v obou repech stejný).

## Problém

Datumová pole v editorech jsou nativní `<input type="date">`, a ten se formátuje podle jazyka **prohlížeče**, ne aplikace. Kdo má anglický systém a českou aplikaci, vidí ve výpisech „01. 09. 2026“, ale edituje „09/01/2026“. U prvních dvanácti dnů měsíce se prohozený měsíc nedá poznat, což je u DUZP nepříjemné.

## Řešení

Nová komponenta `ui/DateInput.vue`, náhrada 1:1 za nativní input (`v-model` zůstává ISO nebo `''`, takže se nemění data, watchery ani API):

- textové pole ve formátu jazyka aplikace (cs `d. m. rrrr`, en `mm/dd/yyyy`), formát odvozený z Intl stejně jako `formatDate()`,
- tolerantní zápis: `1.9.2026`, `01. 09. 2026`, `1.9.26`, `01092026`, i ISO ze schránky,
- neexistující datum (`31. 2.`) pole označí a přes `setCustomValidity` zablokuje odeslání formuláře; datum mimo `min`/`max` má vlastní hlášku,
- nativní kalendář zůstává za ikonou (`showPicker()` s fallbackem), ověřeno v Safari i Chrome,
- žádná nová závislost, vzhled podle `SearchableSelect`.

Nasazeno v editoru vydané faktury (vystaveno, DUZP, splatnost, platební kalendář, výkaz víceprací) a přijaté faktury (vystaveno, DUZP, splatnost, datum přijetí, časové rozlišení položek). Zbylých ~290 nativních date inputů v jiných obrazovkách je mechanická náhrada do navazujících PR, ať je tenhle přehledný.

Drobnosti při tom nalezené v editoru vydané faktury: Ctrl+S teď jde přes `form.requestSubmit()`, takže nativní validace platí i pro zkratku, a `submit()` má pojistku proti dvojímu spuštění během rozběhnutého requestu (stejně jako editor přijatých).

## Otestováno

- 29 unit testů (parser + komponenta, včetně chování ve `<form>`), `pnpm build`, `vue-tsc`, i18n parita.
- Ručně v Safari a Chrome: přepnutí jazyka za běhu, zkrácený zápis, kalendář, přepočet splatnosti po změně data vystavení.
- Manuál: poznámka v kapitolách 15 a 23.

Známá mez: řádky výkazu víceprací a platebního kalendáře jsou klíčované indexem, takže po smazání řádku může instance převzít rozepsaný neplatný text z jiného řádku. Pole je v tom případě viditelně červené a blokuje uložení, nic se tiše nepřepíše. Čistě to vyřeší stabilní klíče řádků, což je zásah nad rámec tohoto PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
