### PR TITLE
fix(banka): párovat přijaté faktury i podle platebního VS a zahrnout zaokrouhlení

### DIFF
--- a/api/src/Service/Bank/StatementMatcher.php
+++ b/api/src/Service/Bank/StatementMatcher.php
@@ -24,8 +24,8 @@ use PDO;
  *   1. Příchozí (amount > 0) — hledá fakturu se shodným varsymbol
  *      a) |amount - amount_to_pay| <= 0.05 Kč → 'auto_exact', faktura → paid
  *      b) |amount - amount_to_pay| <= 1 Kč → 'auto_partial' (částečná platba)
- *   2. Odchozí (amount < 0) — hledá přijatou fakturu (varsymbol nebo
- *      vendor_invoice_number), payment_matches N:N.
+ *   2. Odchozí (amount < 0) — hledá přijatou fakturu podle payment_variable_symbol,
+ *      varsymbol nebo vendor_invoice_number a částky včetně zaokrouhlení, payment_matches N:N.
  *
  * Tolerance 0.05 Kč pro exact match: typické zaokrouhlení 21 % DPH na
  * vícepoložkové faktuře dává ±0.01 — ±0.04 Kč rozdíl mezi součtem
@@ -752,25 +752,21 @@ final class StatementMatcher
         // (ať ve výpisu nevisí). Status/paid_at v tom případě nepřepisujeme.
         // Currency guard viz match() — bez něj by EUR výdaj napároval CZK přijatou.
         //
-        // VS lookup: na rozdíl od vystavených faktur (kde klient platí naši `varsymbol`),
-        // u přijatých platíme my dodavateli — do bank převodu typicky vepíšeme
-        // **VS dodavatele** = `vendor_invoice_number`. Náš `purchase_invoices.varsymbol`
-        // je interní PF-YYYYMM-NNNN, jen občas se s `vendor_invoice_number` shodují
-        // (když user nepoužívá auto-counter). Hledáme proto OR na obojí — uživatel může
-        // platit pod naším PF-... i pod původním číslem dodavatele.
-        // Přesná shoda na náš VS i VS dodavatele + numerická shoda po normalizaci
-        // (číslo dokladu s pomlčkou „PF-2026-0001" × jen-číslice z banky). Viz match().
+        // Platební VS může být jiný než číslo dokladu. Zachováváme i hledání
+        // podle interního a dodavatelského čísla, včetně numerické normalizace.
         $vsDigits = VariableSymbolNormalizer::digits($vs);
         $settled = PurchaseSettledExpr::settled('pi');
         $sql = "SELECT pi.id, pi.varsymbol, pi.vendor_invoice_number,
-                       COALESCE(pi.amount_to_pay, pi.total_with_vat, 0) AS amount_to_pay,
+                       COALESCE(pi.amount_to_pay, pi.total_with_vat, 0) + COALESCE(pi.rounding, 0) AS amount_to_pay,
                        ({$settled}) AS settled_amount,
                        pi.exchange_rate, pi.status, cur.code AS currency,
-                       CASE WHEN pi.varsymbol = ? OR pi.vendor_invoice_number = ? THEN 2 ELSE 1 END AS vs_match_rank
+                       CASE WHEN pi.payment_variable_symbol = ? OR pi.varsymbol = ? OR pi.vendor_invoice_number = ? THEN 2 ELSE 1 END AS vs_match_rank
                   FROM purchase_invoices pi
              LEFT JOIN currencies cur ON cur.id = pi.currency_id
                  WHERE pi.supplier_id = ?
-                   AND (pi.varsymbol = ? OR pi.vendor_invoice_number = ?
+                   AND (pi.payment_variable_symbol = ? OR pi.varsymbol = ? OR pi.vendor_invoice_number = ?
+                        OR (pi.payment_variable_symbol REGEXP '[1-9]'
+                            AND CAST(REGEXP_REPLACE(pi.payment_variable_symbol, '[^0-9]', '') AS UNSIGNED) = CAST(? AS UNSIGNED))
                         OR (pi.varsymbol REGEXP '[1-9]'
                             AND CAST(REGEXP_REPLACE(pi.varsymbol, '[^0-9]', '') AS UNSIGNED) = CAST(? AS UNSIGNED))
                         OR (pi.vendor_invoice_number REGEXP '[1-9]'
@@ -783,7 +779,7 @@ final class StatementMatcher
                  -- těch, které trefila až normalizace na číslice (viz preferExactVsMatches).
                  ORDER BY vs_match_rank DESC, pi.id LIMIT 5";
         $stmt = $pdo->prepare($sql);
-        $stmt->execute([$vs, $vs, $supplierId, $vs, $vs, $vsDigits, $vsDigits]);
+        $stmt->execute([$vs, $vs, $vs, $supplierId, $vs, $vs, $vs, $vsDigits, $vsDigits, $vsDigits]);
         $matches = $this->preferExactVsMatches($stmt->fetchAll(PDO::FETCH_ASSOC) ?: []);
         if (count($matches) > 1) {
             return ['status' => 'unmatched', 'reason' => 'ambiguous_vs_purchase', 'tx_currency' => $txCurrency];
@@ -923,7 +919,7 @@ final class StatementMatcher
         // Měnu nefiltrujeme v SQL — částku porovnáváme přes expectedMatch (cizoměnová
         // faktura placená kartou z CZK účtu se přepočte kurzem faktury).
         $settled = PurchaseSettledExpr::settled('pi');
-        $sql = "SELECT pi.id, COALESCE(pi.amount_to_pay, pi.total_with_vat, 0) AS amount_to_pay,
+        $sql = "SELECT pi.id, COALESCE(pi.amount_to_pay, pi.total_with_vat, 0) + COALESCE(pi.rounding, 0) AS amount_to_pay,
                        ({$settled}) AS settled_amount,
                        pi.exchange_rate, c.company_name AS vendor_name, cur.code AS currency
                   FROM purchase_invoices pi
@@ -1022,7 +1018,7 @@ final class StatementMatcher
             $win = self::AMOUNT_DATE_DAY_WINDOW;
             $stmt = $pdo->prepare(
                 "SELECT pi.id, pi.status, pi.paid_at, pi.payment_method,
-                        COALESCE(pi.amount_to_pay, pi.total_with_vat, 0) AS amount_to_pay,
+                        COALESCE(pi.amount_to_pay, pi.total_with_vat, 0) + COALESCE(pi.rounding, 0) AS amount_to_pay,
                         ({$settled}) AS settled_amount,
                         cur.code AS currency, c.company_name AS vendor_name
                    FROM purchase_invoices pi
@@ -1186,9 +1182,9 @@ final class StatementMatcher
         }
         $digits = VariableSymbolNormalizer::digits($vs);
         $stmt = $pdo->prepare(
-            "SELECT pi.id, COALESCE(pi.amount_to_pay, pi.total_with_vat, 0) AS amount_to_pay,
+            "SELECT pi.id, COALESCE(pi.amount_to_pay, pi.total_with_vat, 0) + COALESCE(pi.rounding, 0) AS amount_to_pay,
                     pi.exchange_rate, cur.code AS currency,
-                    CASE WHEN pi.varsymbol = ? OR pi.vendor_invoice_number = ? THEN 2 ELSE 1 END AS vs_match_rank
+                    CASE WHEN pi.payment_variable_symbol = ? OR pi.varsymbol = ? OR pi.vendor_invoice_number = ? THEN 2 ELSE 1 END AS vs_match_rank
                FROM purchase_invoices pi LEFT JOIN currencies cur ON cur.id = pi.currency_id
               WHERE pi.supplier_id = ? AND pi.document_kind = 'credit_note'
                 -- 'paid' v setu ze stejného důvodu jako v matchPurchase(): dobropis bývá
@@ -1196,11 +1192,13 @@ final class StatementMatcher
                 -- visí ve výpisu nespárovaná a úhrada se nezaúčtuje (221/321), takže
                 -- závazek 321 zůstane v deníku otevřený. paid_at nepřepisujeme (viz UPDATE níž).
                 AND pi.status IN ('received','booked','paid')
-                AND (pi.varsymbol = ? OR pi.vendor_invoice_number = ?
+                AND (pi.payment_variable_symbol = ? OR pi.varsymbol = ? OR pi.vendor_invoice_number = ?
+                        OR (pi.payment_variable_symbol REGEXP '[1-9]'
+                            AND CAST(REGEXP_REPLACE(pi.payment_variable_symbol, '[^0-9]', '') AS UNSIGNED) = CAST(? AS UNSIGNED))
                      OR (pi.varsymbol REGEXP '[1-9]' AND CAST(REGEXP_REPLACE(pi.varsymbol, '[^0-9]', '') AS UNSIGNED) = CAST(? AS UNSIGNED))
                      OR (pi.vendor_invoice_number REGEXP '[1-9]' AND CAST(REGEXP_REPLACE(pi.vendor_invoice_number, '[^0-9]', '') AS UNSIGNED) = CAST(? AS UNSIGNED)))"
         );
-        $stmt->execute([$vs, $vs, $supplierId, $vs, $vs, $digits, $digits]);
+        $stmt->execute([$vs, $vs, $vs, $supplierId, $vs, $vs, $vs, $digits, $digits, $digits]);
         $matches = [];
         foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
             if ((string) $row['currency'] !== self::LOCAL_CURRENCY) continue;

--- a/api/tests/Integration/Bank/PurchaseMatchActivityLogTest.php
+++ b/api/tests/Integration/Bank/PurchaseMatchActivityLogTest.php
@@ -13,6 +13,7 @@ use MyInvoice\Service\ActivityLogger;
 use MyInvoice\Service\Bank\StatementMatcher;
 use MyInvoice\Service\Invoice\FinalFromProformaCreator;
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Slim\Psr7\Factory\ServerRequestFactory;
@@ -257,6 +258,96 @@ final class PurchaseMatchActivityLogTest extends TestCase
         self::assertSame(1, (int) $this->db->pdo()->query(
             "SELECT COUNT(*) FROM payment_matches WHERE bank_transaction_id = {$this->transactionId}"
         )->fetchColumn());
+    }
+
+    public static function purchaseRounding(): array
+    {
+        return [
+            'zaokrouhlení dolů' => [-0.24],
+            'zaokrouhlení nahoru' => [0.36],
+        ];
+    }
+
+    #[DataProvider('purchaseRounding')]
+    public function testFuzzyMatchRequiresRoundedAmountAndStillNeedsReview(float $rounding): void
+    {
+        $this->seed(2500.00, 'received', null, self::VENDOR_MARKER . ' Brno CZE');
+        $pdo = $this->db->pdo();
+        $pdo->prepare('UPDATE purchase_invoices SET rounding = ? WHERE id = ?')
+            ->execute([$rounding, $this->purchaseId]);
+
+        $unrounded = $this->matcher->match($this->transactionId);
+
+        self::assertSame('unmatched', $unrounded['status'] ?? null);
+        self::assertSame('no_fuzzy_match', $unrounded['reason'] ?? null);
+        self::assertArrayNotHasKey('purchase_invoice_id', $unrounded);
+
+        $amount = round(2500.00 + $rounding, 2);
+        $pdo->prepare('UPDATE bank_transactions SET amount = ? WHERE id = ?')
+            ->execute([-$amount, $this->transactionId]);
+
+        $rounded = $this->matcher->match($this->transactionId);
+
+        self::assertSame('unmatched', $rounded['status'] ?? null);
+        self::assertSame('fuzzy_match_requires_review', $rounded['reason'] ?? null);
+        self::assertSame($this->purchaseId, $rounded['purchase_invoice_id'] ?? null);
+        self::assertTrue($rounded['requires_review'] ?? false);
+        self::assertTrue($rounded['fuzzy'] ?? false);
+        self::assertSame('received', $pdo->query(
+            "SELECT status FROM purchase_invoices WHERE id = {$this->purchaseId}"
+        )->fetchColumn());
+        self::assertSame('unmatched', $pdo->query(
+            "SELECT match_status FROM bank_transactions WHERE id = {$this->transactionId}"
+        )->fetchColumn());
+        self::assertSame(0, (int) $pdo->query(
+            "SELECT COUNT(*) FROM payment_matches WHERE bank_transaction_id = {$this->transactionId}"
+        )->fetchColumn());
+    }
+
+    #[DataProvider('purchaseRounding')]
+    public function testSecondPassUsesRoundedAmountAndRecordsPaymentOnce(float $rounding): void
+    {
+        $this->seed(2500.00, 'received', null);
+        $pdo = $this->db->pdo();
+        $pdo->prepare('UPDATE purchase_invoices SET rounding = ? WHERE id = ?')
+            ->execute([$rounding, $this->purchaseId]);
+
+        $unrounded = $this->matcher->matchBatch([$this->transactionId])[$this->transactionId];
+
+        self::assertSame('unmatched', $unrounded['status'] ?? null);
+        self::assertSame('no_amount_date_match', $unrounded['reason'] ?? null);
+        self::assertSame('received', $pdo->query(
+            "SELECT status FROM purchase_invoices WHERE id = {$this->purchaseId}"
+        )->fetchColumn());
+        self::assertSame(0, (int) $pdo->query(
+            "SELECT COUNT(*) FROM payment_matches WHERE bank_transaction_id = {$this->transactionId}"
+        )->fetchColumn());
+
+        $amount = round(2500.00 + $rounding, 2);
+        $pdo->prepare('UPDATE bank_transactions SET amount = ? WHERE id = ?')
+            ->execute([-$amount, $this->transactionId]);
+
+        $rounded = $this->matcher->matchBatch([$this->transactionId])[$this->transactionId];
+        $repeated = $this->matcher->matchBatch([$this->transactionId])[$this->transactionId];
+
+        self::assertSame('auto_exact', $rounded['status'] ?? null);
+        self::assertSame($this->purchaseId, $rounded['purchase_invoice_id'] ?? null);
+        self::assertTrue($rounded['amount_date'] ?? false);
+        self::assertTrue($rounded['second_pass'] ?? false);
+        self::assertSame('auto_exact', $repeated['status'] ?? null);
+        self::assertTrue($repeated['already_recorded'] ?? false);
+        self::assertSame('paid', $pdo->query(
+            "SELECT status FROM purchase_invoices WHERE id = {$this->purchaseId}"
+        )->fetchColumn());
+        self::assertSame('auto_exact', $pdo->query(
+            "SELECT match_status FROM bank_transactions WHERE id = {$this->transactionId}"
+        )->fetchColumn());
+        $allocations = $pdo->query(
+            "SELECT purchase_invoice_id, amount FROM payment_matches WHERE bank_transaction_id = {$this->transactionId}"
+        )->fetchAll(PDO::FETCH_ASSOC);
+        self::assertCount(1, $allocations);
+        self::assertSame($this->purchaseId, (int) $allocations[0]['purchase_invoice_id']);
+        self::assertEqualsWithDelta($amount, (float) $allocations[0]['amount'], 0.001);
     }
 
     public function testPrimaryPassDefersAmountDateFallback(): void

--- a/api/tests/Unit/Service/Bank/StatementMatcherPurchasePaymentTest.php
+++ b/api/tests/Unit/Service/Bank/StatementMatcherPurchasePaymentTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyInvoice\Tests\Unit\Service\Bank;
+
+use MyInvoice\Infrastructure\Database\Connection;
+use MyInvoice\Service\Bank\StatementMatcher;
+use MyInvoice\Service\Invoice\FinalFromProformaCreator;
+use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/** Skutečné SQL nad izolovanými daty; MariaDB regex funkce emuluje SQLite. */
+final class StatementMatcherPurchasePaymentTest extends TestCase
+{
+    private \Pdo\Sqlite $pdo;
+    private StatementMatcher $matcher;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new \Pdo\Sqlite('sqlite::memory:', null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+        $this->pdo->createFunction('regexp', static fn ($pattern, $value) => preg_match('~' . $pattern . '~', (string) $value));
+        $this->pdo->createFunction('REGEXP_REPLACE', static fn ($value, $pattern, $replacement) => preg_replace('~' . $pattern . '~', $replacement, (string) $value));
+        $this->pdo->createFunction('NOW', static fn () => '2099-06-15 12:00:00');
+        $this->pdo->exec("CREATE TABLE currencies (id INTEGER PRIMARY KEY, code TEXT);
+            INSERT INTO currencies VALUES (1, 'CZK');
+            CREATE TABLE purchase_invoices (
+                id INTEGER PRIMARY KEY, supplier_id INTEGER DEFAULT 1,
+                varsymbol TEXT DEFAULT 'PF-2099-001', vendor_invoice_number TEXT DEFAULT 'FV-2099-002',
+                payment_variable_symbol TEXT, currency_id INTEGER DEFAULT 1,
+                total_with_vat REAL DEFAULT 2500, advance_paid_amount REAL DEFAULT 0,
+                amount_to_pay REAL GENERATED ALWAYS AS (total_with_vat - advance_paid_amount) STORED,
+                rounding REAL DEFAULT 0, exchange_rate REAL, status TEXT DEFAULT 'received',
+                document_kind TEXT DEFAULT 'invoice', paid_at TEXT);
+            CREATE TABLE bank_transactions (id INTEGER PRIMARY KEY, match_status TEXT DEFAULT 'unmatched', matched_at TEXT);
+            INSERT INTO bank_transactions (id) VALUES (1);
+            CREATE TABLE payment_matches (id INTEGER PRIMARY KEY, invoice_id INTEGER, supplier_id INTEGER, bank_transaction_id INTEGER,
+                purchase_invoice_id INTEGER, amount REAL, match_type TEXT, match_confidence INTEGER);
+            CREATE TABLE offset_agreement_items (supplier_id INTEGER, agreement_id INTEGER, doc_type TEXT, doc_id INTEGER, amount REAL);
+            CREATE TABLE offset_agreements (id INTEGER, status TEXT);
+            CREATE TABLE invoice_settlements (id INTEGER, supplier_id INTEGER, doc_type TEXT, doc_id INTEGER, status TEXT, amount REAL);");
+        $this->matcher = new StatementMatcher(
+            $this->createStub(Connection::class),
+            $this->createStub(FinalFromProformaCreator::class),
+        );
+    }
+
+    public static function payments(): array
+    {
+        return [
+            'samostatný platební VS' => ['2099000261', '2099000261', 0.0, 0.0, 0.0],
+            'úvodní nuly' => ['0020990261', '20990261', 0.0, 0.0, 0.0],
+            'zaokrouhlení dolů' => ['2099000261', '2099000261', -0.24, 0.0, 0.0],
+            'zaokrouhlení nahoru' => ['2099000261', '2099000261', 0.36, 0.0, 0.0],
+            'záloha a dřívější úhrada' => ['2099000261', '2099000261', -0.24, 500.0, 300.0],
+            'původní interní číslo' => [null, 'PF-2099-001', -0.24, 0.0, 0.0],
+            'původní dodavatelské číslo' => [null, 'FV-2099-002', 0.36, 0.0, 0.0],
+        ];
+    }
+
+    #[DataProvider('payments')]
+    public function testExactPayment(?string $paymentVs, string $bankVs, float $rounding, float $advance, float $settled): void
+    {
+        $this->pdo->prepare('INSERT INTO purchase_invoices (id, payment_variable_symbol, rounding, advance_paid_amount) VALUES (1, ?, ?, ?)')
+            ->execute([$paymentVs, $rounding, $advance]);
+        if ($settled > 0) {
+            $this->pdo->prepare('INSERT INTO payment_matches (supplier_id, bank_transaction_id, purchase_invoice_id, amount) VALUES (1, 2, 1, ?)')
+                ->execute([$settled]);
+        }
+        $amount = round(2500 + $rounding - $advance - $settled, 2);
+        $result = $this->match($bankVs, $amount);
+        self::assertSame('auto_exact', $result['status']);
+        self::assertSame(1, $result['purchase_invoice_id']);
+        self::assertSame('paid', $this->pdo->query('SELECT status FROM purchase_invoices WHERE id = 1')->fetchColumn());
+        self::assertEqualsWithDelta($amount, (float) $this->pdo->query('SELECT amount FROM payment_matches WHERE bank_transaction_id = 1')->fetchColumn(), 0.001);
+    }
+
+    public function testLiteralPaymentVsWinsOverNormalizedDocumentNumber(): void
+    {
+        $this->pdo->exec("INSERT INTO purchase_invoices (id, varsymbol) VALUES (1, 'PF-2099-0261');
+            INSERT INTO purchase_invoices (id, payment_variable_symbol) VALUES (2, '20990261');");
+        $result = $this->match('20990261', 2500);
+        self::assertSame('auto_exact', $result['status']);
+        self::assertSame(2, $result['purchase_invoice_id']);
+        self::assertSame('received', $this->pdo->query('SELECT status FROM purchase_invoices WHERE id = 1')->fetchColumn());
+    }
+
+    public function testRepeatedPaymentVsRemainsAmbiguous(): void
+    {
+        $this->pdo->exec("INSERT INTO purchase_invoices (id, payment_variable_symbol) VALUES (1, '20990261'), (2, '20990261');");
+        $result = $this->match('20990261', 2500);
+        self::assertSame('ambiguous_vs_purchase', $result['reason']);
+        self::assertSame(0, (int) $this->pdo->query('SELECT COUNT(*) FROM payment_matches')->fetchColumn());
+    }
+
+    public function testAlreadyPaidInvoiceRequiresReview(): void
+    {
+        $this->pdo->exec("INSERT INTO purchase_invoices (id, payment_variable_symbol, status, rounding) VALUES (1, '20990261', 'paid', -0.24);");
+        $result = $this->match('20990261', 2499.76);
+        self::assertSame('already_paid_verify', $result['reason']);
+        self::assertTrue($result['requires_review']);
+        self::assertSame(0, (int) $this->pdo->query('SELECT COUNT(*) FROM payment_matches')->fetchColumn());
+    }
+
+    public function testUnroundedPaymentRemainsPartial(): void
+    {
+        $this->pdo->exec("INSERT INTO purchase_invoices (id, payment_variable_symbol, rounding) VALUES (1, '20990261', 0.36);");
+        $result = $this->match('20990261', 2500);
+        self::assertSame('auto_partial', $result['status']);
+        self::assertSame('received', $this->pdo->query('SELECT status FROM purchase_invoices WHERE id = 1')->fetchColumn());
+    }
+
+    public function testCreditRefundUsesPaymentVsAndRounding(): void
+    {
+        $this->pdo->exec("INSERT INTO purchase_invoices (id, payment_variable_symbol, total_with_vat, rounding, document_kind)
+            VALUES (1, '20990261', -2500.24, 0.24, 'credit_note');");
+        $result = $this->match('20990261', 2500, 'matchPurchaseCreditRefund');
+        self::assertSame('auto_exact', $result['status']);
+        self::assertSame(1, $result['purchase_invoice_id']);
+        self::assertSame('paid', $this->pdo->query('SELECT status FROM purchase_invoices WHERE id = 1')->fetchColumn());
+    }
+
+    private function match(string $vs, float $amount, string $method = 'matchPurchase'): array
+    {
+        return (new \ReflectionMethod($this->matcher, $method))->invoke(
+            $this->matcher, $this->pdo, 1, $vs, $amount, '2099-06-15', 1, 'CZK',
+        );
+    }
+}

--- a/manual/28_Banka.md
+++ b/manual/28_Banka.md
@@ -242,6 +242,13 @@ se propojí s mzdovým závazkem a zaúčtuje pouze jednou.
 | Stav | `Spárováno` (zelená) / `Bez shody` (šedá) / `Ignorováno` (oranž.) |
 | Faktura | Pokud spárováno, číslo faktury (klikatelné) |
 
+Odchozí platby se u přijatých faktur párují také podle **platebního variabilního
+symbolu**, vedle interního a dodavatelského čísla dokladu. Doslovná shoda má
+přednost před numerickou normalizací; nejednoznačné shody vyžadují kontrolu.
+Očekávaná částka zahrnuje **zaokrouhlení dokladu**, odečtené zálohy a již
+zaevidované úhrady. Zaokrouhlení se zohledňuje také při náhradním hledání
+podle protistrany nebo částky a data a při vrácení peněz z přijatého dobropisu.
+
 ### 28.4.1 Částečné platby (více převodů na jednu fakturu)
 
 Příchozí platba se **shodným variabilním symbolem**, ale nižší částkou než


### PR DESCRIPTION
Backport opravy 47c988ab z MyInvoice. StatementMatcher nově hledá přijaté faktury také podle payment_variable_symbol a do očekávané částky zahrnuje zaokrouhlení dokladu. Hledání podle interního a dodavatelského čísla zůstává.

Přenos zachovává přednost doslovné shody před numerickou normalizací, ochranu před nejednoznačným VS, odpočet zaevidovaných úhrad a kontrolu již zaplacených faktur. Zaokrouhlení se promítá i do náhradního hledání podle protistrany nebo částky a data. Stejnou opravu používá párování vratek přijatých dobropisů.

Prošlo 25 cílených testů se 70 kontrolami nad izolovanou SQLite. Všech 12 nových regresních scénářů s původním matcherem selhalo. Architektonická sada a invarianty prošly s přeskočenými testy. Plnou integrační sadu auditní brány blokuje chybějící cfg.php v izolovaném checkoutu. Manuál byl aktualizován a přegenerován do HTML.